### PR TITLE
Adds an index.html using iron-doc-viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<!--
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE
+The complete set of authors may be found at http://polymer.github.io/AUTHORS
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS
+-->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <script src="../webcomponentsjs/webcomponents-lite.js"></script>
+    <link rel="import" href="../iron-doc-viewer/iron-doc-viewer.html">
+  </head>
+
+  <body>
+    <iron-doc-viewer src="service-worker-elements.html"></iron-doc-viewer>
+  </body>
+</html>


### PR DESCRIPTION
R: @ebidel @wibblymat @addyosmani 

Follows the patterns used by other elements. It looks like using `src="service-worker-elements.html"` will take care of generating docs for all the sub-elements that it imports.
