### PR TITLE
Update sw-toolbox to ^2.0.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "polymer": "Polymer/polymer#^1.0.0",
-    "sw-toolbox": "^2.0.0"
+    "sw-toolbox": "^2.0.2"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.2",


### PR DESCRIPTION
R: @wibblymat @addyosmani 

Explicitly require at least v2.0.2 of `sw-toolbox`, primarily to pick up https://github.com/GoogleChrome/sw-toolbox/pull/11

I'll tag the v1.0.1 release of `<platinum-sw>` following the merge.