### PR TITLE
Add auto-register to the inline examples

### DIFF
--- a/platinum-sw-cache.html
+++ b/platinum-sw-cache.html
@@ -17,7 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * `<platinum-sw-cache>` needs to be a child element of `<platinum-sw-register>`.
    * A simple, yet useful configuration is
    *
-   *     <platinum-sw-register>
+   *     <platinum-sw-register auto-register>
    *       <platinum-sw-cache></platinum-sw-cache>
    *     </platinum-sw-register>
    *

--- a/platinum-sw-fetch.html
+++ b/platinum-sw-fetch.html
@@ -31,7 +31,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    *
    * An example configuration is:
    *
-   *     <platinum-sw-register>
+   *     <platinum-sw-register auto-register>
    *       <platinum-sw-import-script href="custom-fetch-handler.js"></platinum-sw-import-script>
    *       <platinum-sw-fetch handler="customFetchHandler"
    *                          path="/(.*)/customFetch"></platinum-sw-fetch>

--- a/platinum-sw-import-script.html
+++ b/platinum-sw-import-script.html
@@ -18,7 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    * A common use case is to define a custom request handler for a `fetch` event, but it can be used
    * for any type of code that you want to be executed by the service worker.
    *
-   *     <platinum-sw-register>
+   *     <platinum-sw-register auto-register>
    *       <platinum-sw-import-script href="custom-fetch-handler.js"></platinum-sw-import-script>
    *       <platinum-sw-fetch handler="customFetchHandler"
    *                          path="/(.*)/customFetch"></platinum-sw-fetch>


### PR DESCRIPTION
R: @wibblymat @wibblymat 

This should lead to a slightly better copy-and-paste developer experience.