### PR TITLE
New <platinum-sw-offline-analytics> element

### DIFF
--- a/bootstrap/offline-analytics.js
+++ b/bootstrap/offline-analytics.js
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+(function(global) {
+  var OFFLINE_ANALYTICS_DB_NAME = 'offline-analytics';
+  var EXPIRATION_TIME_DELTA = 86400000; // One day, in milliseconds.
+  var ORIGIN = /https?:\/\/((www|ssl)\.)?google-analytics\.com/;
+
+  function replayQueuedAnalyticsRequests() {
+    global.simpleDB.open(OFFLINE_ANALYTICS_DB_NAME).then(function(db) {
+      db.forEach(function(url, originalTimestamp) {
+        var timeDelta = Date.now() - originalTimestamp;
+        // See https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#qt
+        var replayUrl = url + '&qt=' + timeDelta;
+
+        console.log('About to replay:', replayUrl);
+        global.fetch(replayUrl).then(function(response) {
+          if (response.status >= 500) {
+            // This will cause the promise to reject, triggering the .catch() function.
+            return Response.error();
+          }
+
+          console.log('Replay succeeded:', replayUrl);
+          db.delete(url);
+        }).catch(function(error) {
+          if (timeDelta > EXPIRATION_TIME_DELTA) {
+            // After a while, Google Analytics will no longer accept an old ping with a qt=
+            // parameter. The advertised time is ~4 hours, but we'll attempt to resend up to 24
+            // hours. This logic also prevents the requests from being queued indefinitely.
+            console.error('Replay failed, but the original request is too old to retry any ' +
+              'further. Error:', error);
+            db.delete(url);
+          } else {
+            console.error('Replay failed, and will be retried the next time the service worker ' +
+              'starts. Error:', error);
+          }
+        });
+      });
+    });
+  }
+
+  function queueFailedAnalyticsRequest(request) {
+    console.log('Queueing failed request:', request);
+
+    global.simpleDB.open(OFFLINE_ANALYTICS_DB_NAME).then(function(db) {
+      db.set(request.url, Date.now());
+    });
+  }
+
+  function handleAnalyticsCollectionRequest(request) {
+    return global.fetch(request).then(function(response) {
+      if (response.status >= 500) {
+        // This will cause the promise to reject, triggering the .catch() function.
+        // It will also result in a generic HTTP error being returned to the controlled page.
+        return Response.error();
+      } else {
+        return response;
+      }
+    }).catch(function() {
+      queueFailedAnalyticsRequest(request);
+    });
+  }
+
+  global.toolbox.router.get('/collect', handleAnalyticsCollectionRequest, {origin: ORIGIN});
+  global.toolbox.router.get('/analytics.js', global.toolbox.networkFirst, {origin: ORIGIN});
+
+  replayQueuedAnalyticsRequests();
+})(self);

--- a/bootstrap/simple-db.js
+++ b/bootstrap/simple-db.js
@@ -1,0 +1,173 @@
+/**
+ * @license
+ * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+// From https://gist.github.com/inexorabletash/c8069c042b734519680c (Joshua Bell)
+
+(function(global) {
+  var SECRET = Object.create(null);
+  var DB_PREFIX = '$SimpleDB$';
+  var STORE = 'store';
+
+  // Chrome iOS has window.indexeDB, but it is null.
+  if (!(global.indexedDB && indexedDB.open)) {
+    return;
+  }
+
+  function SimpleDBFactory(secret) {
+    if (secret !== SECRET) throw TypeError('Invalid constructor');
+  }
+  SimpleDBFactory.prototype = {
+    open: function(name) {
+      return new Promise(function(resolve, reject) {
+        var request = indexedDB.open(DB_PREFIX + name);
+        request.onupgradeneeded = function() {
+          var db = request.result;
+          db.createObjectStore(STORE);
+        };
+        request.onsuccess = function() {
+          var db = request.result;
+          resolve(new SimpleDB(SECRET, name, db));
+        };
+        request.onerror = function() {
+          reject(request.error);
+        };
+      });
+    },
+    delete: function(name) {
+      return new Promise(function(resolve, reject) {
+        var request = indexedDB.deleteDatabase(DB_PREFIX + name);
+        request.onsuccess = function() {
+          resolve(undefined);
+        };
+        request.onerror = function() {
+          reject(request.error);
+        };
+      });
+    }
+  };
+
+  function SimpleDB(secret, name, db) {
+    if (secret !== SECRET) throw TypeError('Invalid constructor');
+    this._name = name;
+    this._db = db;
+  }
+  SimpleDB.cmp = indexedDB.cmp;
+  SimpleDB.prototype = {
+    get name() {
+      return this._name;
+    },
+    get: function(key) {
+      var that = this;
+      return new Promise(function(resolve, reject) {
+        var tx = that._db.transaction(STORE, 'readwrite');
+        var store = tx.objectStore(STORE);
+        var req = store.get(key);
+        // NOTE: Could also use req.onsuccess/onerror
+        tx.oncomplete = function() { resolve(req.result); };
+        tx.onabort = function() { reject(tx.error); };
+      });
+    },
+    set: function(key, value) {
+      var that = this;
+      return new Promise(function(resolve, reject) {
+        var tx = that._db.transaction(STORE, 'readwrite');
+        var store = tx.objectStore(STORE);
+        var req = store.put(value, key);
+        tx.oncomplete = function() { resolve(undefined); };
+        tx.onabort = function() { reject(tx.error); };
+      });
+    },
+    delete: function(key) {
+      var that = this;
+      return new Promise(function(resolve, reject) {
+        var tx = that._db.transaction(STORE, 'readwrite');
+        var store = tx.objectStore(STORE);
+        var req = store.delete(key);
+        tx.oncomplete = function() { resolve(undefined); };
+        tx.onabort = function() { reject(tx.error); };
+      });
+    },
+    clear: function() {
+      var that = this;
+      return new Promise(function(resolve, reject) {
+        var tx = that._db.transaction(STORE, 'readwrite');
+        var store = tx.objectStore(STORE);
+        var request = store.clear();
+        tx.oncomplete = function() { resolve(undefined); };
+        tx.onabort = function() { reject(tx.error); };
+      });
+    },
+    forEach: function(callback, options) {
+      var that = this;
+      return new Promise(function(resolve, reject) {
+        options = options || {};
+        var tx = that._db.transaction(STORE, 'readwrite');
+        var store = tx.objectStore(STORE);
+        var request = store.openCursor(
+          options.range,
+          options.direction === 'reverse' ? 'prev' : 'next');
+        request.onsuccess = function() {
+          var cursor = request.result;
+          if (!cursor) return;
+          try {
+            var terminate = callback(cursor.key, cursor.value);
+            if (!terminate) cursor.continue();
+          } catch (ex) {
+            tx.abort(); // ???
+          }
+        };
+        tx.oncomplete = function() { resolve(undefined); };
+        tx.onabort = function() { reject(tx.error); };
+      });
+    },
+    getMany: function(keys) {
+      var that = this;
+      return new Promise(function(resolve, reject) {
+        var tx = that._db.transaction(STORE, 'readwrite');
+        var store = tx.objectStore(STORE);
+        var results = [];
+        keys.forEach(function(key) {
+          store.get(key).onsuccess(function(result) {
+            results.push(result);
+          });
+        });
+        tx.oncomplete = function() { resolve(results); };
+        tx.onabort = function() { reject(tx.error); };
+      });
+    },
+    setMany: function(entries) {
+      var that = this;
+      return new Promise(function(resolve, reject) {
+        var tx = that._db.transaction(STORE, 'readwrite');
+        var store = tx.objectStore(STORE);
+        entries.forEach(function(entry) {
+          store.put(entry.value, entry.key);
+        });
+        tx.oncomplete = function() { resolve(undefined); };
+        tx.onabort = function() { reject(tx.error); };
+      });
+    },
+    deleteMany: function(keys) {
+      var that = this;
+      return new Promise(function(resolve, reject) {
+        var tx = that._db.transaction(STORE, 'readwrite');
+        var store = tx.objectStore(STORE);
+        keys.forEach(function(key) {
+          store.delete(key);
+        });
+        tx.oncomplete = function() { resolve(undefined); };
+        tx.onabort = function() { reject(tx.error); };
+      });
+    }
+  };
+
+  global.simpleDB = new SimpleDBFactory(SECRET);
+  global.SimpleDBKeyRange = IDBKeyRange;
+}(self));

--- a/bootstrap/sw-toolbox-setup.js
+++ b/bootstrap/sw-toolbox-setup.js
@@ -8,35 +8,38 @@
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-var swToolboxURL = new URL('../sw-toolbox/sw-toolbox.js', params.get('baseURI')).href;
-importScripts(swToolboxURL);
-
-if (params.has('cacheId')) {
-  toolbox.options.cacheName = params.get('cacheId') + '$$$' + self.registration.scope;
-}
-
-if (params.has('defaultCacheStrategy')) {
-  var strategy = params.get('defaultCacheStrategy');
-  toolbox.router.default = toolbox[strategy] || self[strategy];
-}
-
-if (params.has('precache')) {
-  toolbox.precache(params.get('precache'));
-}
-
-if (params.has('route')) {
-  var setsOfRouteParams = params.get('route');
-  while (setsOfRouteParams.length > 0) {
-    var routeParams = setsOfRouteParams.splice(0, 3);
-    var originParam;
-    if (routeParams[2]) {
-      originParam = {origin: new RegExp(routeParams[2])};
-    }
-    var handler = toolbox[routeParams[1]] || self[routeParams[1]];
-    if (typeof handler === 'function') {
-      toolbox.router.get(routeParams[0], handler, originParam);
-    } else {
-      console.error('Unable to register sw-toolbox route: ', routeParams);
+(function(global) {
+  var swToolboxURL = new URL('../sw-toolbox/sw-toolbox.js', global.params.get('baseURI')).href;
+  importScripts(swToolboxURL);
+  
+  if (global.params.has('cacheId')) {
+    global.toolbox.options.cacheName = global.params.get('cacheId') + '$$$' +
+      global.registration.scope;
+  }
+  
+  if (global.params.has('defaultCacheStrategy')) {
+    var strategy = global.params.get('defaultCacheStrategy');
+    global.toolbox.router.default = global.toolbox[strategy] || global[strategy];
+  }
+  
+  if (global.params.has('precache')) {
+    global.toolbox.precache(global.params.get('precache'));
+  }
+  
+  if (global.params.has('route')) {
+    var setsOfRouteParams = global.params.get('route');
+    while (setsOfRouteParams.length > 0) {
+      var routeParams = setsOfRouteParams.splice(0, 3);
+      var originParam;
+      if (routeParams[2]) {
+        originParam = {origin: new RegExp(routeParams[2])};
+      }
+      var handler = global.toolbox[routeParams[1]] || global[routeParams[1]];
+      if (typeof handler === 'function') {
+        global.toolbox.router.get(routeParams[0], handler, originParam);
+      } else {
+        console.error('Unable to register sw-toolbox route: ', routeParams);
+      }
     }
   }
-}
+})(self);

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "platinum-sw",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "http://polymer.github.io/LICENSE.txt",
   "authors": [
     "The Polymer Authors"

--- a/platinum-sw-elements.html
+++ b/platinum-sw-elements.html
@@ -11,4 +11,5 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="platinum-sw-cache.html">
 <link rel="import" href="platinum-sw-fetch.html">
 <link rel="import" href="platinum-sw-import-script.html">
+<link rel="import" href="platinum-sw-offline-analytics.html">
 <link rel="import" href="platinum-sw-register.html">

--- a/platinum-sw-offline-analytics.html
+++ b/platinum-sw-offline-analytics.html
@@ -1,0 +1,55 @@
+<!--
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<link rel="import" href="../polymer/polymer.html">
+
+<script>
+  /**
+   * The `<platinum-sw-offline-analytics>` element registers a service worker handler to
+   * intercepts requests for Google Analytics pings.
+   *
+   * If the HTTP GET for the ping is successful (because the browser is online), then everything
+   * proceeds as it normally would. If the HTTP GET fails, the ping request is saved to IndexedDB, and each time the service worker
+   * script starts up it will attempt to "replay" those saved ping requests, giving up after one day
+   * has passed.
+   *
+   * The [`qt`](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#qt)
+   * URL parameter is automatically added to the replayed HTTP GET and set to the number of
+   * milliseconds that has passed since the initial ping request was attempted, to ensure that the
+   * original time attribution is correct.
+   *
+   * `<platinum-sw-offline-analytics>` does not take care of setting up Google Analytics on your
+   * page, and assumes that you have [properly configured](https://support.google.com/analytics/answer/1008080)
+   * Google Analytics tracking code registered elsewhere on your page.
+   *
+   * Since `<platinum-sw-offline-analytics>` is only useful if the page that is being tracked with
+   * Google Analytics works offline, it's best used in conjunction with the `<platinum-sw-cache>`
+   * element, which takes care of caching your site's resources and serving them while offline.
+   *
+   * A basic configuration is
+   *
+   *     <platinum-sw-register auto-register>
+   *       <platinum-sw-offline-analytics></platinum-sw-offline-analytics>
+   *       <platinum-sw-cache></platinum-sw-cache>
+   *     </platinum-sw-register>
+   *
+   */
+  Polymer({
+    is: 'platinum-sw-offline-analytics',
+
+    _getParameters: function(baseURI) {
+      return Promise.resolve({
+        importscript: new URL('bootstrap/simple-db.js', baseURI).href,
+        importscriptLate: [
+          new URL('bootstrap/sw-toolbox-setup.js', baseURI).href,
+          new URL('bootstrap/offline-analytics.js', baseURI).href
+        ]
+      });
+    }
+  });
+</script>

--- a/platinum-sw-register.html
+++ b/platinum-sw-register.html
@@ -252,9 +252,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         paramsResolutions.forEach(function(childParams) {
           Object.keys(childParams).forEach(function(key) {
             if (Array.isArray(params[key])) {
-              params[key].push(childParams[key]);
+              params[key] = params[key].concat(childParams[key]);
             } else {
-              params[key] = [childParams[key]];
+              params[key] = [].concat(childParams[key]);
             }
           });
         });
@@ -272,6 +272,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (params.importscript) {
           params.importscript = this._unique(params.importscript);
         }
+
+        // We've already concatenated importscriptLate, so don't include it in the serialized URL.
+        delete params.importscriptLate;
 
         params.clientsClaim = this.clientsClaim;
         params.skipWaiting = this.skipWaiting;

--- a/service-worker.js
+++ b/service-worker.js
@@ -8,45 +8,47 @@
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-var VERSION = '1.0';
-
-function deserializeUrlParams(queryString) {
-  return new Map(queryString.split('&').map(function(keyValuePair) {
-    var splits = keyValuePair.split('=');
-    var key = decodeURIComponent(splits[0]);
-    var value = decodeURIComponent(splits[1]);
-    if (value.indexOf(',') >= 0) {
-      value = value.split(',');
-    }
-
-    return [key, value];
-  }));
-}
-
-self.params = deserializeUrlParams(location.search.substring(1));
-
-if (params.get('version') !== VERSION) {
-  throw 'The registered script is version ' + VERSION +
-        ' and cannot be used with <platinum-sw-register> version ' + params.get('version');
-}
-
-if (params.has('importscript')) {
-  var scripts = params.get('importscript');
-  if (Array.isArray(scripts)) {
-    importScripts.apply(null, scripts);
-  } else {
-    importScripts(scripts);
+(function(global) {
+  var VERSION = '1.0';
+  
+  function deserializeUrlParams(queryString) {
+    return new Map(queryString.split('&').map(function(keyValuePair) {
+      var splits = keyValuePair.split('=');
+      var key = decodeURIComponent(splits[0]);
+      var value = decodeURIComponent(splits[1]);
+      if (value.indexOf(',') >= 0) {
+        value = value.split(',');
+      }
+  
+      return [key, value];
+    }));
   }
-}
-
-if (params.get('skipWaiting') === 'true' && self.skipWaiting) {
-  self.addEventListener('install', function(e) {
-    e.waitUntil(self.skipWaiting());
-  });
-}
-
-if (params.get('clientsClaim') === 'true' && self.clients && self.clients.claim) {
-  self.addEventListener('activate', function(e) {
-    e.waitUntil(self.clients.claim());
-  });
-}
+  
+  global.params = deserializeUrlParams(location.search.substring(1));
+  
+  if (global.params.get('version') !== VERSION) {
+    throw 'The registered script is version ' + VERSION +
+          ' and cannot be used with <platinum-sw-register> version ' + global.params.get('version');
+  }
+  
+  if (global.params.has('importscript')) {
+    var scripts = global.params.get('importscript');
+    if (Array.isArray(scripts)) {
+      importScripts.apply(null, scripts);
+    } else {
+      importScripts(scripts);
+    }
+  }
+  
+  if (global.params.get('skipWaiting') === 'true' && global.skipWaiting) {
+    global.addEventListener('install', function(e) {
+      e.waitUntil(global.skipWaiting());
+    });
+  }
+  
+  if (global.params.get('clientsClaim') === 'true' && global.clients && global.clients.claim) {
+    global.addEventListener('activate', function(e) {
+      e.waitUntil(global.clients.claim());
+    });
+  }
+})(self);


### PR DESCRIPTION
R: @addyosmani @wibblymat 

This adds support for queueing and resending Google Analytics pings while offline, via a new `<platinum-sw-offline-analytics>` element. The element itself is bare-bones, and effectively just imports a few existing helper libraries into the service worker: one to wrap IndexDB, and the other to deal with the Google Analytics queueing and replaying. 

I've also wrapped some existing service worker helper libraries in an IIFE for cleanliness, and fixed a bug that I found with the way the parameters are serialized in `<platinum-sw-register>`.

I haven't put together tests for the new element. I'm at a loss for how to meaningfully simulate the full fail/queue/replay cycle, since all the code runs in the service worker.

The diff is cleanest to read with [`w=1`](https://github.com/PolymerElements/platinum-sw/pull/55/files?w=1)