### PR TITLE
Workaround for M47 HTTP 204 Response bug

### DIFF
--- a/test/platinum-sw-fetch/custom-fetch-handler.js
+++ b/test/platinum-sw-fetch/custom-fetch-handler.js
@@ -1,6 +1,6 @@
-self.custom204FetchHandler = function(request) {
+self.custom203FetchHandler = function(request) {
   return new Response('', {
-    status: 204,
+    status: 203,
     statusText: 'Via customFetchHandler'
   });
 };

--- a/test/platinum-sw-fetch/index.html
+++ b/test/platinum-sw-fetch/index.html
@@ -23,7 +23,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <body>
     <platinum-sw-register skip-waiting clients-claim auto-register>
-      <platinum-sw-fetch handler="custom204FetchHandler"
+      <platinum-sw-fetch handler="custom203FetchHandler"
                          path="/(.*)customFetch"></platinum-sw-fetch>
       <platinum-sw-fetch handler="custom410FetchHandler"
                          path="/(.*)customFetch"
@@ -36,7 +36,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('the same-origin custom fetch handler is used when the path matches', function() {
           return navigator.serviceWorker.ready.then(function() {
             return window.fetch('customFetch').then(function(response) {
-              assert.equal(response.status, 204, 'Custom response status doesn\'t match');
+              assert.equal(response.status, 203, 'Custom response status doesn\'t match');
             });
           });
         });


### PR DESCRIPTION
R: @wibblymat @addyosmani @ebidel 

A [change](https://codereview.chromium.org/1258933002) that went live as part of Chrome 47 makes it impossible to construct a HTTP 204 `Response` object.

I opened [a bug](https://code.google.com/p/chromium/issues/detail?id=524500) about this regression, but in the meantime, it's easy enough to just switch to a HTTP 203 `Response` in the test.