### PR TITLE
Adds redirect-to-https

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "platinum-sw",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "http://polymer.github.io/LICENSE.txt",
   "authors": [
     "The Polymer Authors"

--- a/demo/index.html
+++ b/demo/index.html
@@ -24,6 +24,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <platinum-sw-register skip-waiting
                             clients-claim
                             reload-on-install
+                            redirect-to-https
                             state="{{state}}">
         <platinum-sw-cache default-cache-strategy="networkFirst"
                            precache="{{precacheList}}"></platinum-sw-cache>

--- a/platinum-sw-register.html
+++ b/platinum-sw-register.html
@@ -156,13 +156,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * website isn't accessible via `https:` then there's no reason to add these elements to your
        * pages in the first place.
        *
-       * The following logic is used to handle the redirect, which will not be triggered if the site
-       * is running off of a local server on a port other than `80`:
+       * The following logic is used to handle the redirect, which will excludes pages loaded via
+       * localhost:
        *
        *     if (this.redirectToHttps &&
-       *         (!location.port || location.port === '80') &&
-       *         location.protocol === 'http:') {
-       *       location.protocol = 'https:';
+       *         window.location.protocol === 'http:' &&
+       *         window.location.hostname !== 'localhost' &&
+       *         // [::1] is the IPv6 localhost address.
+       *         window.location.hostname !== '[::1]' &&
+       *         // If this is an IPv4 address that doesn't start with 127., then redirect to https:
+       *         !window.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/)) {
+       *       window.location.protocol = 'https:';
        *     }
        */
       redirectToHttps: {
@@ -377,13 +381,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     attached: function() {
-      // If redirectToHttps is set, and we're running on what appears to be a "production" web
-      // server (i.e. one that runs on port 80), then redirect to the https: version of the site if
-      // http: is currently being used.
       if (this.redirectToHttps &&
-          (!location.port || location.port === '80') &&
-          location.protocol === 'http:') {
-        location.protocol = 'https:';
+          window.location.protocol === 'http:' &&
+          window.location.hostname !== 'localhost' &&
+          // [::1] is the IPv6 localhost address.
+          window.location.hostname !== '[::1]' &&
+          // If this is an IPv4 address that doesn't start with 127., then redirect to https:
+          !window.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/)) {
+        window.location.protocol = 'https:';
       }
 
       if (this.autoRegister) {

--- a/platinum-sw-register.html
+++ b/platinum-sw-register.html
@@ -144,6 +144,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       /**
+       * Whether the page should be automatically navigate to the `https:` version of a site if it's
+       * accessed via `http:`.
+       *
+       * Service workers [require HTTPS](http://www.chromium.org/Home/chromium-security/prefer-secure-origins-for-powerful-new-features)
+       * (unless they're accessed via a local web server, e.g. via `http://localhost:8000` or
+       * `http://127.0.0.1:8000`), and setting this option ensures that anyone visiting your site
+       * will get the benefit of your service worker.
+       *
+       * Do not use this option your website is not accessible via `https:`. Of course, if your
+       * website isn't accessible via `https:` then there's no reason to add these elements to your
+       * pages in the first place.
+       *
+       * The following logic is used to handle the redirect, which will not be triggered if the site
+       * is running off of a local server on a port other than `80`:
+       *
+       *     if (this.redirectToHttps &&
+       *         (!location.port || location.port === '80') &&
+       *         location.protocol === 'http:') {
+       *       location.protocol = 'https:';
+       *     }
+       */
+      redirectToHttps: {
+        type: Boolean,
+        value: false
+      },
+
+      /**
        * Whether the page should be automatically reloaded (via `window.location.reload()`) when
        * the service worker is successfully installed.
        *
@@ -350,6 +377,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     attached: function() {
+      // If redirectToHttps is set, and we're running on what appears to be a "production" web
+      // server (i.e. one that runs on port 80), then redirect to the https: version of the site if
+      // http: is currently being used.
+      if (this.redirectToHttps &&
+          (!location.port || location.port === '80') &&
+          location.protocol === 'http:') {
+        location.protocol = 'https:';
+      }
+
       if (this.autoRegister) {
         this.async(this.register);
       }


### PR DESCRIPTION
R: @wibblymat @addyosmani @ebidel @robdodson 

Adds a new `redirectToHttps` parameter which will force a HTTPS redirect when `<platinum-sw-register>` is used on a page that's accessed via HTTP from port 80. This is a useful heuristic that would exclude the redirect when it's used on a development web server.