### PR TITLE
baseUri needs to be absolute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ the Vulcanization process. The recommended approach is to explicitly copy the di
 those helper files into the same directory as the Vulcanized output, which maintains the relative
 paths. The Polymer Starter Kit's [gulpfile.js](https://github.com/PolymerElements/polymer-starter-kit/blob/ee1b0c5ac5dd26e3ac56b12ec36d607ff02dced4/gulpfile.js#L100)
 illustrates one way of doing this. An alternative approach is to use
-`<platinum-sw-register base-uri="path/to/directory">` and hardcode a base URI to use.
+`<platinum-sw-register base-uri="https://example.com/path/to/directory">`
+and hardcode an absolute base URI to use.
 
 ## `cacheOnly` & `cacheFirst` `defaultCacheStrategy` Considered Harmful
 The [`sw-toolbox` library](https://github.com/googlechrome/sw-toolbox),

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "platinum-sw",
   "private": true,
-  "version": "1.2.1",
+  "version": "1.2.2",
   "license": "http://polymer.github.io/LICENSE.txt",
   "authors": [
     "The Polymer Authors"

--- a/platinum-sw-register.html
+++ b/platinum-sw-register.html
@@ -88,7 +88,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       /**
        * The URI used as a base when constructing relative paths to service worker helper libraries
-       * that need to be loaded.
+       * that need to be loaded. If provided, it must be a complete, absolute URI.
        *
        * This can normally be kept set to the default, which will use the directory containing this
        * element as the base. However, if you [Vulcanize](https://github.com/polymer/vulcanize) your
@@ -101,9 +101,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       baseUri: {
         type: String,
         // Grab the URI of this file to use as a base when resolving relative paths.
-        // Fallback to './' as a default, though current browsers that don't support
+        // Fallback to window.location.href as a default, though current browsers that don't support
         // document.currentScript also don't support service workers.
-        value: document.currentScript ? document.currentScript.baseURI : './'
+        value: document.currentScript ? document.currentScript.baseURI : window.location.href
       },
 
       /**


### PR DESCRIPTION
R: @wibblymat 

I feel like `window.location.href` is as good a fallback URI to use as any, since there won't actually be a service worker registered in that case.

Closes #65 