### PR TITLE
If no cacheId is provided, use the correct default

### DIFF
--- a/platinum-sw-cache.html
+++ b/platinum-sw-cache.html
@@ -170,7 +170,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               } else {
                 params.precache = params.precache.concat(config.precache);
               }
-              params.cacheId = config.cacheId || params.cacheId;
+              params.cacheId = config.cacheId || params.cacheId || undefined;
               params.defaultCacheStrategy = config.defaultCacheStrategy ||
                 params.defaultCacheStrategy;
             }


### PR DESCRIPTION
Currently, if you have a precache file with no cacheId the parameters sent to the SW will have `{"cacheId": ""}`. In [sw-toolbox-setup.js](https://github.com/PolymerElements/platinum-sw/blob/master/bootstrap/sw-toolbox-setup.js#L15) we check only that `params.has('cacheId')`, and not that it is a truthy value. Therefore we construct a new default `cacheName` with the empty string as a base.