### PR TITLE
Default scope to "/" instead of "./" to better deal with routing

### DIFF
--- a/platinum-sw-register.html
+++ b/platinum-sw-register.html
@@ -176,7 +176,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       scope: {
         type: String,
-        value: './'
+        value: '/'
       },
 
       /**


### PR DESCRIPTION
In my app, visiting "/" immediately redirects to "/art/list". Because the router does its thing before platinum-sw has had a chance to load up, it seems to be improperly setting the scope to "/art/". I've fixed this in my markup by setting `scope="/"` but it seems like the default should just be "/" unless I'm missing something?

/cc @tjsavage 