### PR TITLE
Don't run tests until the page is under SW control

### DIFF
--- a/test/controlled-promise.js
+++ b/test/controlled-promise.js
@@ -1,0 +1,17 @@
+// Provides an equivalent to navigator.serviceWorker.ready that waits for the page to be controlled,
+// as opposed to waiting for the active service worker.
+// See https://github.com/slightlyoff/ServiceWorker/issues/799
+window._controlledPromise = new Promise(function(resolve) {
+  // Resolve with the registration, to match the .ready promise's behavior.
+  var resolveWithRegistration = function() {
+    navigator.serviceWorker.getRegistration().then(function(registration) {
+      resolve(registration);
+    });
+  };
+
+  if (navigator.serviceWorker.controller) {
+    resolveWithRegistration();
+  } else {
+    navigator.serviceWorker.addEventListener('controllerchange', resolveWithRegistration);
+  }
+});

--- a/test/platinum-sw-cache/index.html
+++ b/test/platinum-sw-cache/index.html
@@ -15,6 +15,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../../web-component-tester/browser.js"></script>
+    <script src="../controlled-promise.js"></script>
 
     <link rel="import" href="../../platinum-sw-register.html">
     <link rel="import" href="../../platinum-sw-cache.html">
@@ -32,7 +33,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         suite('Precaching', function() {
           test('precache results in Cache Storage API entries', function() {
-            return navigator.serviceWorker.ready.then(function() {
+            return window._controlledPromise.then(function() {
               return window.fetch(swc.cacheConfigFile).then(function(response) {
                 return response.json();
               }).then(function(config) {

--- a/test/platinum-sw-fetch/index.html
+++ b/test/platinum-sw-fetch/index.html
@@ -15,6 +15,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../../web-component-tester/browser.js"></script>
+    <script src="../controlled-promise.js"></script>
 
     <link rel="import" href="../../platinum-sw-register.html">
     <link rel="import" href="../../platinum-sw-import-script.html">
@@ -34,13 +35,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script>
       suite('Service Worker Fetch Handlers', function() {
         test('the same-origin custom fetch handler is used when the path matches', function() {
-          return new Promise(function(resolve) {
-            if (navigator.serviceWorker.controller) {
-              resolve();
-            } else {
-              navigator.serviceWorker.addEventListener('controllerchange', resolve);
-            }
-          }).then(function() {
+          return window._controlledPromise.then(function() {
             return window.fetch('customFetch');
           }).then(function(response) {
             assert.equal(response.status, 203, 'Custom response status doesn\'t match');
@@ -48,7 +43,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('the same-origin custom fetch handler isn\'t used when the path doesn\t match', function() {
-          return navigator.serviceWorker.ready.then(function() {
+          return window._controlledPromise.then(function() {
             return window.fetch('dummyUrlThatShould404').then(function(response) {
               assert.equal(response.status, 404, 'Expected response status doesn\'t match');
             });
@@ -56,7 +51,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('the cross-origin fetch handler is used when the path and origin matches', function() {
-          return navigator.serviceWorker.ready.then(function() {
+          return window._controlledPromise.then(function() {
             return window.fetch('https://matching.domain/path/to/customFetch').then(function(response) {
               assert.equal(response.status, 410, 'Custom response status doesn\'t match');
             });

--- a/test/platinum-sw-fetch/index.html
+++ b/test/platinum-sw-fetch/index.html
@@ -34,10 +34,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script>
       suite('Service Worker Fetch Handlers', function() {
         test('the same-origin custom fetch handler is used when the path matches', function() {
-          return navigator.serviceWorker.ready.then(function() {
-            return window.fetch('customFetch').then(function(response) {
-              assert.equal(response.status, 203, 'Custom response status doesn\'t match');
-            });
+          return new Promise(function(resolve) {
+            if (navigator.serviceWorker.controller) {
+              resolve();
+            } else {
+              navigator.serviceWorker.addEventListener('controllerchange', resolve);
+            }
+          }).then(function() {
+            return window.fetch('customFetch');
+          }).then(function(response) {
+            assert.equal(response.status, 203, 'Custom response status doesn\'t match');
           });
         });
 

--- a/test/platinum-sw-import-script/index.html
+++ b/test/platinum-sw-import-script/index.html
@@ -15,6 +15,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../../web-component-tester/browser.js"></script>
+    <script src="../controlled-promise.js"></script>
 
     <link rel="import" href="../../platinum-sw-register.html">
     <link rel="import" href="../../platinum-sw-import-script.html">
@@ -27,10 +28,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script>
       suite('Importing Service Worker Scripts', function() {
-        // TODO: postMessage/message events are in flux in the Service Worker spec, so this may
-        // need to change in the future.
         test('message handler is registered via imported script', function(done) {
-          return navigator.serviceWorker.ready.then(function(registration) {
+          return window._controlledPromise.then(function(registration) {
             var message = 'hello';
             var messageChannel = new MessageChannel();
             messageChannel.port1.onmessage = function(event) {

--- a/test/platinum-sw-register/index.html
+++ b/test/platinum-sw-register/index.html
@@ -15,6 +15,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../../web-component-tester/browser.js"></script>
+    <script src="../controlled-promise.js"></script>
 
     <link rel="import" href="../../platinum-sw-register.html">
   </head>
@@ -27,7 +28,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       suite('Registration & Installation', function() {
         test('creates an active service worker', function() {
-          return navigator.serviceWorker.ready.then(function(registration) {
+          return window._controlledPromise.then(function(registration) {
             assert.ok(registration.active);
           });
         });


### PR DESCRIPTION
R: @gauntface @wibblymat @addyosmani @ebidel 

As it turns out, @guantface ran into a similar race condition with the `.ready` promise. Switching from it to explicitly waiting on `navigator.serviceWorker.controller` seems to clear up the lingering test flakiness we were seeing.

We'll be following up on the `.ready` promise flakiness out-of-band.

Closes #37 