### PR TITLE
Use document._currentScript when available

### DIFF
--- a/platinum-sw-register.html
+++ b/platinum-sw-register.html
@@ -101,9 +101,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       baseUri: {
         type: String,
         // Grab the URI of this file to use as a base when resolving relative paths.
+        // See https://github.com/webcomponents/webcomponentsjs/blob/88240ba9ef4cebb1579e07f7888c7b58ec017a39/src/HTMLImports/base.js#L31
+        // for background on document._currentScript. We want to support document.currentScript
+        // as well, on the off chance that the polyfills aren't loaded.
         // Fallback to './' as a default, though current browsers that don't support
         // document.currentScript also don't support service workers.
-        value: document.currentScript ? document.currentScript.baseURI : './'
+        value: document._currentScript ? document._currentScript.baseURI :
+          (document.currentScript ? document.currentScript.baseURI : './')
       },
 
       /**
@@ -374,6 +378,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (this.autoRegister) {
         this.async(this.register);
       }
+    },
+
+    ready: function() {
+      console.log(this.baseUri);
     }
   });
 </script>

--- a/platinum-sw-register.html
+++ b/platinum-sw-register.html
@@ -378,10 +378,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (this.autoRegister) {
         this.async(this.register);
       }
-    },
-
-    ready: function() {
-      console.log(this.baseUri);
     }
   });
 </script>


### PR DESCRIPTION
R: @addyosmani @wibblymat @gauntface @ebidel 
CC: @wanderview

The nested conditional ternary operators are ugly, but I've got a few scenarios I need to deal with now:

1. `document._currentScript` is set, because we've got the [HTML Imports polyfill loaded](https://github.com/webcomponents/webcomponentsjs/blob/88240ba9ef4cebb1579e07f7888c7b58ec017a39/src/HTMLImports/base.js#L31) and we're on a browser that supports `document.currentScript` in general.
1. `document._currentScript` isn't set, but `document.currentScript` is, because we don't have the polyfill loaded.
1. Neither `document._currentScript` nor `document.currentScript` are set, because we're in a browser that doesn't support `document.currentScript`, i.e. IE.

Closes #81.