### PR TITLE
Default to [] in precachePromise

### DIFF
--- a/bootstrap/sw-toolbox-setup.js
+++ b/bootstrap/sw-toolbox-setup.js
@@ -39,7 +39,7 @@
       return precache.concat(global.params.get('precache'));
     })
   } else {
-    precachePromise = Promise.resolve(global.params.get('precache'));
+    precachePromise = Promise.resolve(global.params.get('precache') || []);
   }
 
   global.toolbox.precache(precachePromise);


### PR DESCRIPTION
R: @wibblymat @addyosmani @gauntface

Without this change, `[undefined]` is passed to `toolbox.precache()` when there is no precache config. This didn't lead to anything too drastic in earlier versions of Chrome, but starting in Chrome 50, failed fetches in the underlying `cache.addAll()` call will caught the promise to reject.