### PR TITLE
Fix typo in platinum-sw-register documentation

### DIFF
--- a/platinum-sw-register.html
+++ b/platinum-sw-register.html
@@ -186,7 +186,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * ```
        *
        * So by default, registering `/root/service-worker.js` will cause the service worker's scope
-       * to cover `/root/index.html`, `/root/subdir1/index.html`, and /root/subdir2/index.html`.
+       * to cover `/root/index.html`, `/root/subdir1/index.html`, and `/root/subdir2/index.html`.
        *
        * If, for some reason, you need to register `/root/service-worker.js` from within
        * `/root/subdir1/index.html`, *and* you want that registration to only cover


### PR DESCRIPTION
Trivial fix for missing \`.