### PR TITLE
Documentation to state sw use HTTPS only

### DIFF
--- a/platinum-sw-register.html
+++ b/platinum-sw-register.html
@@ -27,6 +27,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    *                           on-service-worker-installed="handleSWInstalled">
    *       ...one or more <platinum-sw-*> children which share the service worker registration...
    *     </platinum-sw-register>
+   * Please note that service workers will only work on HTTPS. Therefore, any <platinum-sw-*> children will silently error on a HTTP connection. This error can be viewed on the event object in the `on-service-worker-error` callback. With one exception to this, `localhost` is white listed and will work on HTTP.
    *
    * Please see https://github.com/PolymerElements/platinum-sw#top-level-sw-importjs for a
    * *crucial* prerequisite file you must create before `<platinum-sw-register>` can be used!


### PR DESCRIPTION
Please see [Documentation needs to state service workers will work only on https. #101](https://github.com/PolymerElements/platinum-sw/issues/101) and [Caching with platinum-sw-register #106](https://github.com/PolymerElements/polymer-starter-kit/issues/106#issuecomment-218355213)

> Description
>    Service workers only work on HTTPS. They will fail silently by default on HTTP. I say 'default' because without on-service-worker-error the error will not appear on dev console which is the usual convention. For example, Google map api will give getCurrentPosition() and watchPosition() are deprecated on insecure origins warning in console without any handler.

Solution:

![pic2](https://cloud.githubusercontent.com/assets/887815/15237260/ed42e79c-1891-11e6-84f4-1e095e90244b.jpg)
