### PR TITLE
Automatic format!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ before_script:
     npm run update-types && git diff --exit-code || (echo -e
     '\n\033[31mERROR:\033[0m Typings are stale. Please run "npm run
     update-types".' && false)
+  - >-
+    npm run format && git diff --exit-code || (echo -e '\n\033[31mERROR:\033[0m
+    Project is not formatted. Please run "npm run format".' && false)
 script:
   - xvfb-run polymer test
   - >-

--- a/bootstrap/offline-analytics.js
+++ b/bootstrap/offline-analytics.js
@@ -1,66 +1,77 @@
 /**
  * @license
  * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 (function(global) {
-  var OFFLINE_ANALYTICS_DB_NAME = 'offline-analytics';
-  var EXPIRATION_TIME_DELTA = 86400000; // One day, in milliseconds.
-  var ORIGIN = /https?:\/\/((www|ssl)\.)?google-analytics\.com/;
+var OFFLINE_ANALYTICS_DB_NAME = 'offline-analytics';
+var EXPIRATION_TIME_DELTA = 86400000;  // One day, in milliseconds.
+var ORIGIN = /https?:\/\/((www|ssl)\.)?google-analytics\.com/;
 
-  function replayQueuedAnalyticsRequests() {
-    global.simpleDB.open(OFFLINE_ANALYTICS_DB_NAME).then(function(db) {
-      db.forEach(function(url, originalTimestamp) {
-        var timeDelta = Date.now() - originalTimestamp;
-        // See https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#qt
-        var replayUrl = url + '&qt=' + timeDelta;
+function replayQueuedAnalyticsRequests() {
+  global.simpleDB.open(OFFLINE_ANALYTICS_DB_NAME).then(function(db) {
+    db.forEach(function(url, originalTimestamp) {
+      var timeDelta = Date.now() - originalTimestamp;
+      // See
+      // https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#qt
+      var replayUrl = url + '&qt=' + timeDelta;
 
-        Polymer.Base._log('About to replay:', replayUrl);
-        global.fetch(replayUrl).then(function(response) {
-          if (response.status >= 500) {
-            // This will cause the promise to reject, triggering the .catch() function.
-            return Response.error();
-          }
-          db.delete(url);
-        }).catch(function(error) {
-          if (timeDelta > EXPIRATION_TIME_DELTA) {
-            // After a while, Google Analytics will no longer accept an old ping with a qt=
-            // parameter. The advertised time is ~4 hours, but we'll attempt to resend up to 24
-            // hours. This logic also prevents the requests from being queued indefinitely.
+      Polymer.Base._log('About to replay:', replayUrl);
+      global.fetch(replayUrl)
+          .then(function(response) {
+            if (response.status >= 500) {
+              // This will cause the promise to reject, triggering the .catch()
+              // function.
+              return Response.error();
+            }
             db.delete(url);
-          }
-        });
+          })
+          .catch(function(error) {
+            if (timeDelta > EXPIRATION_TIME_DELTA) {
+              // After a while, Google Analytics will no longer accept an old
+              // ping with a qt= parameter. The advertised time is ~4 hours, but
+              // we'll attempt to resend up to 24 hours. This logic also
+              // prevents the requests from being queued indefinitely.
+              db.delete(url);
+            }
+          });
+    });
+  });
+}
+
+function queueFailedAnalyticsRequest(request) {
+  global.simpleDB.open(OFFLINE_ANALYTICS_DB_NAME).then(function(db) {
+    db.set(request.url, Date.now());
+  });
+}
+
+function handleAnalyticsCollectionRequest(request) {
+  return global.fetch(request)
+      .then(function(response) {
+        if (response.status >= 500) {
+          // This will cause the promise to reject, triggering the .catch()
+          // function. It will also result in a generic HTTP error being
+          // returned to the controlled page.
+          return Response.error();
+        } else {
+          return response;
+        }
+      })
+      .catch(function() {
+        queueFailedAnalyticsRequest(request);
       });
-    });
-  }
+}
 
-  function queueFailedAnalyticsRequest(request) {
-    global.simpleDB.open(OFFLINE_ANALYTICS_DB_NAME).then(function(db) {
-      db.set(request.url, Date.now());
-    });
-  }
+global.toolbox.router.get(
+    '/collect', handleAnalyticsCollectionRequest, {origin: ORIGIN});
+global.toolbox.router.get(
+    '/analytics.js', global.toolbox.networkFirst, {origin: ORIGIN});
 
-  function handleAnalyticsCollectionRequest(request) {
-    return global.fetch(request).then(function(response) {
-      if (response.status >= 500) {
-        // This will cause the promise to reject, triggering the .catch() function.
-        // It will also result in a generic HTTP error being returned to the controlled page.
-        return Response.error();
-      } else {
-        return response;
-      }
-    }).catch(function() {
-      queueFailedAnalyticsRequest(request);
-    });
-  }
-
-  global.toolbox.router.get('/collect', handleAnalyticsCollectionRequest, {origin: ORIGIN});
-  global.toolbox.router.get('/analytics.js', global.toolbox.networkFirst, {origin: ORIGIN});
-
-  replayQueuedAnalyticsRequests();
+replayQueuedAnalyticsRequests();
 })(self);

--- a/bootstrap/simple-db.js
+++ b/bootstrap/simple-db.js
@@ -1,173 +1,210 @@
 /**
  * @license
  * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-// From https://gist.github.com/inexorabletash/c8069c042b734519680c (Joshua Bell)
+// From https://gist.github.com/inexorabletash/c8069c042b734519680c (Joshua
+// Bell)
 
 (function(global) {
-  var SECRET = Object.create(null);
-  var DB_PREFIX = '$SimpleDB$';
-  var STORE = 'store';
+var SECRET = Object.create(null);
+var DB_PREFIX = '$SimpleDB$';
+var STORE = 'store';
 
-  // Chrome iOS has window.indexeDB, but it is null.
-  if (!(global.indexedDB && indexedDB.open)) {
-    return;
+// Chrome iOS has window.indexeDB, but it is null.
+if (!(global.indexedDB && indexedDB.open)) {
+  return;
+}
+
+function SimpleDBFactory(secret) {
+  if (secret !== SECRET)
+    throw TypeError('Invalid constructor');
+}
+SimpleDBFactory.prototype = {
+  open: function(name) {
+    return new Promise(function(resolve, reject) {
+      var request = indexedDB.open(DB_PREFIX + name);
+      request.onupgradeneeded = function() {
+        var db = request.result;
+        db.createObjectStore(STORE);
+      };
+      request.onsuccess = function() {
+        var db = request.result;
+        resolve(new SimpleDB(SECRET, name, db));
+      };
+      request.onerror = function() {
+        reject(request.error);
+      };
+    });
+  },
+  delete: function(name) {
+    return new Promise(function(resolve, reject) {
+      var request = indexedDB.deleteDatabase(DB_PREFIX + name);
+      request.onsuccess = function() {
+        resolve(undefined);
+      };
+      request.onerror = function() {
+        reject(request.error);
+      };
+    });
   }
+};
 
-  function SimpleDBFactory(secret) {
-    if (secret !== SECRET) throw TypeError('Invalid constructor');
+function SimpleDB(secret, name, db) {
+  if (secret !== SECRET)
+    throw TypeError('Invalid constructor');
+  this._name = name;
+  this._db = db;
+}
+SimpleDB.cmp = indexedDB.cmp;
+SimpleDB.prototype = {
+  get name() {
+    return this._name;
+  },
+  get: function(key) {
+    var that = this;
+    return new Promise(function(resolve, reject) {
+      var tx = that._db.transaction(STORE, 'readwrite');
+      var store = tx.objectStore(STORE);
+      var req = store.get(key);
+      // NOTE: Could also use req.onsuccess/onerror
+      tx.oncomplete = function() {
+        resolve(req.result);
+      };
+      tx.onabort = function() {
+        reject(tx.error);
+      };
+    });
+  },
+  set: function(key, value) {
+    var that = this;
+    return new Promise(function(resolve, reject) {
+      var tx = that._db.transaction(STORE, 'readwrite');
+      var store = tx.objectStore(STORE);
+      var req = store.put(value, key);
+      tx.oncomplete = function() {
+        resolve(undefined);
+      };
+      tx.onabort = function() {
+        reject(tx.error);
+      };
+    });
+  },
+  delete: function(key) {
+    var that = this;
+    return new Promise(function(resolve, reject) {
+      var tx = that._db.transaction(STORE, 'readwrite');
+      var store = tx.objectStore(STORE);
+      var req = store.delete(key);
+      tx.oncomplete = function() {
+        resolve(undefined);
+      };
+      tx.onabort = function() {
+        reject(tx.error);
+      };
+    });
+  },
+  clear: function() {
+    var that = this;
+    return new Promise(function(resolve, reject) {
+      var tx = that._db.transaction(STORE, 'readwrite');
+      var store = tx.objectStore(STORE);
+      var request = store.clear();
+      tx.oncomplete = function() {
+        resolve(undefined);
+      };
+      tx.onabort = function() {
+        reject(tx.error);
+      };
+    });
+  },
+  forEach: function(callback, options) {
+    var that = this;
+    return new Promise(function(resolve, reject) {
+      options = options || {};
+      var tx = that._db.transaction(STORE, 'readwrite');
+      var store = tx.objectStore(STORE);
+      var request = store.openCursor(
+          options.range, options.direction === 'reverse' ? 'prev' : 'next');
+      request.onsuccess = function() {
+        var cursor = request.result;
+        if (!cursor)
+          return;
+        try {
+          var terminate = callback(cursor.key, cursor.value);
+          if (!terminate)
+            cursor.continue();
+        } catch (ex) {
+          tx.abort();  // ???
+        }
+      };
+      tx.oncomplete = function() {
+        resolve(undefined);
+      };
+      tx.onabort = function() {
+        reject(tx.error);
+      };
+    });
+  },
+  getMany: function(keys) {
+    var that = this;
+    return new Promise(function(resolve, reject) {
+      var tx = that._db.transaction(STORE, 'readwrite');
+      var store = tx.objectStore(STORE);
+      var results = [];
+      keys.forEach(function(key) {
+        store.get(key).onsuccess(function(result) {
+          results.push(result);
+        });
+      });
+      tx.oncomplete = function() {
+        resolve(results);
+      };
+      tx.onabort = function() {
+        reject(tx.error);
+      };
+    });
+  },
+  setMany: function(entries) {
+    var that = this;
+    return new Promise(function(resolve, reject) {
+      var tx = that._db.transaction(STORE, 'readwrite');
+      var store = tx.objectStore(STORE);
+      entries.forEach(function(entry) {
+        store.put(entry.value, entry.key);
+      });
+      tx.oncomplete = function() {
+        resolve(undefined);
+      };
+      tx.onabort = function() {
+        reject(tx.error);
+      };
+    });
+  },
+  deleteMany: function(keys) {
+    var that = this;
+    return new Promise(function(resolve, reject) {
+      var tx = that._db.transaction(STORE, 'readwrite');
+      var store = tx.objectStore(STORE);
+      keys.forEach(function(key) {
+        store.delete(key);
+      });
+      tx.oncomplete = function() {
+        resolve(undefined);
+      };
+      tx.onabort = function() {
+        reject(tx.error);
+      };
+    });
   }
-  SimpleDBFactory.prototype = {
-    open: function(name) {
-      return new Promise(function(resolve, reject) {
-        var request = indexedDB.open(DB_PREFIX + name);
-        request.onupgradeneeded = function() {
-          var db = request.result;
-          db.createObjectStore(STORE);
-        };
-        request.onsuccess = function() {
-          var db = request.result;
-          resolve(new SimpleDB(SECRET, name, db));
-        };
-        request.onerror = function() {
-          reject(request.error);
-        };
-      });
-    },
-    delete: function(name) {
-      return new Promise(function(resolve, reject) {
-        var request = indexedDB.deleteDatabase(DB_PREFIX + name);
-        request.onsuccess = function() {
-          resolve(undefined);
-        };
-        request.onerror = function() {
-          reject(request.error);
-        };
-      });
-    }
-  };
+};
 
-  function SimpleDB(secret, name, db) {
-    if (secret !== SECRET) throw TypeError('Invalid constructor');
-    this._name = name;
-    this._db = db;
-  }
-  SimpleDB.cmp = indexedDB.cmp;
-  SimpleDB.prototype = {
-    get name() {
-      return this._name;
-    },
-    get: function(key) {
-      var that = this;
-      return new Promise(function(resolve, reject) {
-        var tx = that._db.transaction(STORE, 'readwrite');
-        var store = tx.objectStore(STORE);
-        var req = store.get(key);
-        // NOTE: Could also use req.onsuccess/onerror
-        tx.oncomplete = function() { resolve(req.result); };
-        tx.onabort = function() { reject(tx.error); };
-      });
-    },
-    set: function(key, value) {
-      var that = this;
-      return new Promise(function(resolve, reject) {
-        var tx = that._db.transaction(STORE, 'readwrite');
-        var store = tx.objectStore(STORE);
-        var req = store.put(value, key);
-        tx.oncomplete = function() { resolve(undefined); };
-        tx.onabort = function() { reject(tx.error); };
-      });
-    },
-    delete: function(key) {
-      var that = this;
-      return new Promise(function(resolve, reject) {
-        var tx = that._db.transaction(STORE, 'readwrite');
-        var store = tx.objectStore(STORE);
-        var req = store.delete(key);
-        tx.oncomplete = function() { resolve(undefined); };
-        tx.onabort = function() { reject(tx.error); };
-      });
-    },
-    clear: function() {
-      var that = this;
-      return new Promise(function(resolve, reject) {
-        var tx = that._db.transaction(STORE, 'readwrite');
-        var store = tx.objectStore(STORE);
-        var request = store.clear();
-        tx.oncomplete = function() { resolve(undefined); };
-        tx.onabort = function() { reject(tx.error); };
-      });
-    },
-    forEach: function(callback, options) {
-      var that = this;
-      return new Promise(function(resolve, reject) {
-        options = options || {};
-        var tx = that._db.transaction(STORE, 'readwrite');
-        var store = tx.objectStore(STORE);
-        var request = store.openCursor(
-          options.range,
-          options.direction === 'reverse' ? 'prev' : 'next');
-        request.onsuccess = function() {
-          var cursor = request.result;
-          if (!cursor) return;
-          try {
-            var terminate = callback(cursor.key, cursor.value);
-            if (!terminate) cursor.continue();
-          } catch (ex) {
-            tx.abort(); // ???
-          }
-        };
-        tx.oncomplete = function() { resolve(undefined); };
-        tx.onabort = function() { reject(tx.error); };
-      });
-    },
-    getMany: function(keys) {
-      var that = this;
-      return new Promise(function(resolve, reject) {
-        var tx = that._db.transaction(STORE, 'readwrite');
-        var store = tx.objectStore(STORE);
-        var results = [];
-        keys.forEach(function(key) {
-          store.get(key).onsuccess(function(result) {
-            results.push(result);
-          });
-        });
-        tx.oncomplete = function() { resolve(results); };
-        tx.onabort = function() { reject(tx.error); };
-      });
-    },
-    setMany: function(entries) {
-      var that = this;
-      return new Promise(function(resolve, reject) {
-        var tx = that._db.transaction(STORE, 'readwrite');
-        var store = tx.objectStore(STORE);
-        entries.forEach(function(entry) {
-          store.put(entry.value, entry.key);
-        });
-        tx.oncomplete = function() { resolve(undefined); };
-        tx.onabort = function() { reject(tx.error); };
-      });
-    },
-    deleteMany: function(keys) {
-      var that = this;
-      return new Promise(function(resolve, reject) {
-        var tx = that._db.transaction(STORE, 'readwrite');
-        var store = tx.objectStore(STORE);
-        keys.forEach(function(key) {
-          store.delete(key);
-        });
-        tx.oncomplete = function() { resolve(undefined); };
-        tx.onabort = function() { reject(tx.error); };
-      });
-    }
-  };
-
-  global.simpleDB = new SimpleDBFactory(SECRET);
-  global.SimpleDBKeyRange = IDBKeyRange;
+global.simpleDB = new SimpleDBFactory(SECRET);
+global.SimpleDBKeyRange = IDBKeyRange;
 }(self));

--- a/bootstrap/sw-toolbox-setup.js
+++ b/bootstrap/sw-toolbox-setup.js
@@ -1,63 +1,72 @@
 /**
  * @license
  * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 (function(global) {
-  var swToolboxURL = new URL('../sw-toolbox/sw-toolbox.js', global.params.get('baseURI')).href;
-  importScripts(swToolboxURL);
+var swToolboxURL =
+    new URL('../sw-toolbox/sw-toolbox.js', global.params.get('baseURI')).href;
+importScripts(swToolboxURL);
 
-  var cacheId = global.params.get('cacheId');
-  if (cacheId) {
-    global.toolbox.options.cacheName = cacheId + '$$$' + global.registration.scope;
-  }
+var cacheId = global.params.get('cacheId');
+if (cacheId) {
+  global.toolbox.options.cacheName =
+      cacheId + '$$$' + global.registration.scope;
+}
 
-  if (global.params.has('defaultCacheStrategy')) {
-    var strategy = global.params.get('defaultCacheStrategy');
-    global.toolbox.router.default = global.toolbox[strategy] || global[strategy];
-  }
+if (global.params.has('defaultCacheStrategy')) {
+  var strategy = global.params.get('defaultCacheStrategy');
+  global.toolbox.router.default = global.toolbox[strategy] || global[strategy];
+}
 
-  var precachePromise;
-  // When precacheFingerprint is present inside the cacheConfigFile JSON, its a signal that instead
-  // of reading the list of URLs to precache from the service worker's URL parameters, we need to
-  // instead fetch the JSON file and read the list of precache URLs for there. This works around
-  // the problem that the list of URLs to precache might be longer than the browser-specific limit
-  // on the size of a service worker's URL.
-  if (global.params.has('precacheFingerprint') && global.params.has('cacheConfigFile')) {
-    precachePromise = global.fetch(global.params.get('cacheConfigFile')).then(function(response) {
-      return response.json();
-    }).then(function(json) {
-      return json.precache || [];
-    }).catch(function(error) {
-      return [];
-    }).then(function(precache) {
-      return precache.concat(global.params.get('precache'));
-    })
-  } else {
-    precachePromise = Promise.resolve(global.params.get('precache') || []);
-  }
+var precachePromise;
+// When precacheFingerprint is present inside the cacheConfigFile JSON, its a
+// signal that instead of reading the list of URLs to precache from the service
+// worker's URL parameters, we need to instead fetch the JSON file and read the
+// list of precache URLs for there. This works around the problem that the list
+// of URLs to precache might be longer than the browser-specific limit on the
+// size of a service worker's URL.
+if (global.params.has('precacheFingerprint') &&
+    global.params.has('cacheConfigFile')) {
+  precachePromise = global.fetch(global.params.get('cacheConfigFile'))
+                        .then(function(response) {
+                          return response.json();
+                        })
+                        .then(function(json) {
+                          return json.precache || [];
+                        })
+                        .catch(function(error) {
+                          return [];
+                        })
+                        .then(function(precache) {
+                          return precache.concat(global.params.get('precache'));
+                        })
+} else {
+  precachePromise = Promise.resolve(global.params.get('precache') || []);
+}
 
-  global.toolbox.precache(precachePromise);
+global.toolbox.precache(precachePromise);
 
-  if (global.params.has('route')) {
-    var setsOfRouteParams = global.params.get('route');
-    while (setsOfRouteParams.length > 0) {
-      var routeParams = setsOfRouteParams.splice(0, 3);
-      var originParam;
-      if (routeParams[2]) {
-        originParam = {origin: new RegExp(routeParams[2])};
-      }
-      var handler = global.toolbox[routeParams[1]] || global[routeParams[1]];
-      if (typeof handler === 'function') {
-        global.toolbox.router.get(routeParams[0], handler, originParam);
-      } else {
-        Polymer.Base._error('Unable to register sw-toolbox route: ', routeParams);
-      }
+if (global.params.has('route')) {
+  var setsOfRouteParams = global.params.get('route');
+  while (setsOfRouteParams.length > 0) {
+    var routeParams = setsOfRouteParams.splice(0, 3);
+    var originParam;
+    if (routeParams[2]) {
+      originParam = {origin: new RegExp(routeParams[2])};
+    }
+    var handler = global.toolbox[routeParams[1]] || global[routeParams[1]];
+    if (typeof handler === 'function') {
+      global.toolbox.router.get(routeParams[0], handler, originParam);
+    } else {
+      Polymer.Base._error('Unable to register sw-toolbox route: ', routeParams);
     }
   }
+}
 })(self);

--- a/demo/index.html
+++ b/demo/index.html
@@ -57,16 +57,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script>
       var t = document.querySelector('#page-template');
 
-      t.books = [{
-        title: 'Don Quixote',
-        url: 'https://cdn.rawgit.com/GITenberg/Don-Quixote_996/master/996.txt'
-      }, {
-        title: 'Dubliners',
-        url: 'https://cdn.rawgit.com/GITenberg/Dubliners_2814/master/2814.txt'
-      }, {
-        title: 'Pride & Prejudice',
-        url: 'https://cdn.rawgit.com/GITenberg/Pride-and-Prejudice_1342/master/1342.txt'
-      }];
+      t.books = [
+        {
+          title: 'Don Quixote',
+          url: 'https://cdn.rawgit.com/GITenberg/Don-Quixote_996/master/996.txt'
+        },
+        {
+          title: 'Dubliners',
+          url: 'https://cdn.rawgit.com/GITenberg/Dubliners_2814/master/2814.txt'
+        },
+        {
+          title: 'Pride & Prejudice',
+          url:
+              'https://cdn.rawgit.com/GITenberg/Pride-and-Prejudice_1342/master/1342.txt'
+        }
+      ];
 
       t.precacheList = t.books.map(function(book) {
         return book.url;
@@ -75,16 +80,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       t.selectBook = function(e) {
         var books = document.querySelector('#books');
         var selectedBook = books.itemForElement(e.target.selectedOptions[0]);
-        window.fetch(selectedBook.url).then(function(response) {
-          return response.text();
-        }).then(function(text) {
-          t.text = text;
-        });
+        window.fetch(selectedBook.url)
+            .then(function(response) {
+              return response.text();
+            })
+            .then(function(text) {
+              t.text = text;
+            });
       };
 
       window.addEventListener('WebComponentsReady', function() {
-        // Explicitly call the register() method. We need to wait until the template's variables are
-        // all set first, since the configuration depends on bound variables.
+        // Explicitly call the register() method. We need to wait until the template's
+        // variables are all set first, since the configuration depends on bound
+        // variables.
         document.querySelector('platinum-sw-register').register();
       });
     </script>

--- a/demo/sw-import.js
+++ b/demo/sw-import.js
@@ -1,10 +1,11 @@
 /**
 @license
 Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 importScripts('../service-worker.js');

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,23 +3,34 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@mrmlnc/readdir-enhanced": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "1.0.1",
+        "glob-to-regexp": "0.3.0"
+      }
+    },
     "@polymer/gen-typescript-declarations": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@polymer/gen-typescript-declarations/-/gen-typescript-declarations-1.2.0.tgz",
-      "integrity": "sha512-a5DFXI3TdZSVOMH4608LVaBLmcr+mwM2+B8OSBiB9WFNCtdqzUXwtB5We6vBzrThXlO4uRo7d2pEqjNXMAlEkA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@polymer/gen-typescript-declarations/-/gen-typescript-declarations-1.2.2.tgz",
+      "integrity": "sha512-9P946+nIkSm+761v3oxH/QVgJozhsInldKY3h8AVstdXkA8W0Fij84pqsFv1nrRuPGj4Pv71crzoZpFnLkNmKQ==",
       "dev": true,
       "requires": {
         "@types/doctrine": "0.0.3",
-        "@types/fs-extra": "5.0.0",
+        "@types/fs-extra": "5.0.1",
         "@types/glob": "5.0.35",
         "command-line-args": "5.0.2",
-        "command-line-usage": "4.1.0",
+        "command-line-usage": "5.0.4",
         "doctrine": "2.1.0",
-        "escodegen": "1.9.0",
+        "escodegen": "1.9.1",
         "fs-extra": "5.0.0",
         "glob": "7.1.2",
         "minimatch": "3.0.4",
-        "polymer-analyzer": "3.0.0-pre.12"
+        "polymer-analyzer": "3.0.0-pre.14",
+        "vscode-uri": "1.0.3"
       }
     },
     "@types/babel-generator": {
@@ -95,18 +106,18 @@
       "dev": true
     },
     "@types/events": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
-      "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
       "dev": true
     },
     "@types/fs-extra": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.0.tgz",
-      "integrity": "sha512-qtxDULQKUenuaDLW003CgC+0T0eiAfH3BrH+vSt87GLzbz5EZ6Ox6mv9rMttvhDOatbb9nYh0E1m7ydoYwUrAg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.1.tgz",
+      "integrity": "sha512-h3wnflb+jMTipvbbZnClgA2BexrT4w0GcfoCz5qyxd0IRsbqhLSyesM6mqZTAnhbVmhyTm5tuxfRu9R+8l+lGw==",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.6"
+        "@types/node": "9.6.4"
       }
     },
     "@types/glob": {
@@ -115,10 +126,16 @@
       "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
       "dev": true,
       "requires": {
-        "@types/events": "1.1.0",
+        "@types/events": "1.2.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "9.4.6"
+        "@types/node": "9.6.4"
       }
+    },
+    "@types/is-windows": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@types/is-windows/-/is-windows-0.2.0.tgz",
+      "integrity": "sha1-byTuSHMdMRaOpRBhDW3RXl/Jxv8=",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -127,9 +144,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "9.4.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.6.tgz",
-      "integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ==",
+      "version": "9.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.4.tgz",
+      "integrity": "sha512-Awg4BcUYiZtNKoveGOu654JVPt11V/KIC77iBz8NweyoOAZpz5rUJfPDwwD+ajfTs2HndbTCEB8IuLfX9m/mmw==",
       "dev": true
     },
     "@types/parse5": {
@@ -138,25 +155,25 @@
       "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.6"
+        "@types/node": "9.6.4"
+      }
+    },
+    "@types/resolve": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.6.tgz",
+      "integrity": "sha512-g+Rg8uMWY76oYTyaL+m7ZcblqF/oj7pE6uEUyACluJx4zcop1Lk14qQiocdEkEVMDFm6DmKpxJhsER+ZuTwG3g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "9.6.4"
       }
     },
     "@types/winston": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.3.8.tgz",
-      "integrity": "sha512-QqR0j08RCS1AQYPMRPHikEpcmK+2aEEbcSzWLwOqyJ4FhLmHUx/WjRrnn7tTQg/y4IKnMhzskh/o7qvGIZZ7iA==",
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.3.9.tgz",
+      "integrity": "sha512-zzruYOEtNgfS3SBjcij1F6HlH6My5n8WrBNhP3fzaRM22ba70QBC2ATs18jGr88Fy43c0z8vFJv5wJankfxv2A==",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.6"
-      }
-    },
-    "ansi-escape-sequences": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.0.0.tgz",
-      "integrity": "sha512-v+0wW9Wezwsyb0uF4aBVCjmSqit3Ru7PZFziGF0o2KwTvN2zWfTi3BRLq9EkJFdg3eBbyERXGTntVpBxH1J68Q==",
-      "dev": true,
-      "requires": {
-        "array-back": "2.0.0"
+        "@types/node": "9.6.4"
       }
     },
     "ansi-regex": {
@@ -166,10 +183,13 @@
       "dev": true
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "1.9.1"
+      }
     },
     "argv-tools": {
       "version": "0.1.1",
@@ -181,6 +201,24 @@
         "find-replace": "2.0.1"
       }
     },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
     "array-back": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
@@ -190,19 +228,37 @@
         "typical": "2.6.1"
       }
     },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
     "async": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
       "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
       "dev": true
     },
+    "atob": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
+      "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw==",
+      "dev": true
+    },
     "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-beta.3.tgz",
+      "integrity": "sha512-flMsJ9eSpShupt2Gwpka84DoMePvE4HlDObzdEc+1iNkacv3+NHlsJ7dMKmbnVA/AT22UhcGEBHwbJLoXWBO6Q==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
+        "chalk": "2.3.2",
         "esutils": "2.0.2",
         "js-tokens": "3.0.2"
       }
@@ -221,6 +277,47 @@
         "lodash": "4.17.5",
         "source-map": "0.5.7",
         "trim-right": "1.0.1"
+      },
+      "dependencies": {
+        "babel-types": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.5",
+            "to-fast-properties": "1.0.3"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "babel-helper-function-name": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.3.tgz",
+      "integrity": "sha512-iMWYqwDarQOVlEGcK1MfbtK9vrFGs5Z4UQsdASJUHdhBp918EM5kndwriiIbhUX8gr2B/CEV/udJkFTrHsjdMQ==",
+      "dev": true,
+      "requires": {
+        "babel-helper-get-function-arity": "7.0.0-beta.3",
+        "babel-template": "7.0.0-beta.3",
+        "babel-traverse": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3"
+      }
+    },
+    "babel-helper-get-function-arity": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.3.tgz",
+      "integrity": "sha512-ZkYFRMWKx1c9fUW72YNM3eieBG701CMbLjmLLWmJTTPc0F0kddS9Fwok26EAmndUAgD6kFdh7ms3PH94MdGuGQ==",
+      "dev": true,
+      "requires": {
+        "babel-types": "7.0.0-beta.3"
       }
     },
     "babel-messages": {
@@ -238,43 +335,78 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.5",
         "regenerator-runtime": "0.11.1"
       }
     },
-    "babel-traverse": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+    "babel-template": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-7.0.0-beta.3.tgz",
+      "integrity": "sha512-urJduLja89kSDGqY8ryw8iIwQnMl30IvhMtMNmDD7vBX0l0oylaLgK+7df/9ODX9vR/PhXuif6HYl5HlzAKXMg==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
+        "babel-code-frame": "7.0.0-beta.3",
+        "babel-traverse": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3",
+        "babylon": "7.0.0-beta.27",
         "lodash": "4.17.5"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.27",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.27.tgz",
+          "integrity": "sha512-ksRx+r8eFIfdt63MCgLc9VxGL7W3jcyveQvMpNMVHgW+eb9mq3Xbm45FLCNkw8h92RvoNp4uuiwzcCEwxjDBZg==",
+          "dev": true
+        }
+      }
+    },
+    "babel-traverse": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-beta.3.tgz",
+      "integrity": "sha512-xyh/aPYuedMAfQlSj2kjHjsEmY5/Dpxs576L05DySAVMrV+ADX6l4mTOLysAEGwJfkePJlDLhFuS6SKaxv1V7w==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "7.0.0-beta.3",
+        "babel-helper-function-name": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3",
+        "babylon": "7.0.0-beta.27",
+        "debug": "3.1.0",
+        "globals": "10.4.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.5"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.27",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.27.tgz",
+          "integrity": "sha512-ksRx+r8eFIfdt63MCgLc9VxGL7W3jcyveQvMpNMVHgW+eb9mq3Xbm45FLCNkw8h92RvoNp4uuiwzcCEwxjDBZg==",
+          "dev": true
+        }
       }
     },
     "babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.3.tgz",
+      "integrity": "sha512-36k8J+byAe181OmCMawGhw+DtKO7AwexPVtsPXoMfAkjtZgoCX3bEuHWfdE5sYxRM8dojvtG/+O08M0Z/YDC6w==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
         "esutils": "2.0.2",
         "lodash": "4.17.5",
-        "to-fast-properties": "1.0.3"
+        "to-fast-properties": "2.0.0"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
       }
     },
     "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+      "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
       "dev": true
     },
     "balanced-match": {
@@ -283,10 +415,65 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
+    },
     "bower": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.2.tgz",
-      "integrity": "sha1-rfU1KcjUrwLvJPuNU0HBQZ0z4vc=",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.4.tgz",
+      "integrity": "sha1-54dqB23rgTf30GUl3F6MZtuC8oo=",
       "dev": true
     },
     "brace-expansion": {
@@ -299,23 +486,157 @@
         "concat-map": "0.0.1"
       }
     },
-    "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+    "braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
+        "arr-flatten": "1.1.0",
+        "array-unique": "0.3.2",
+        "extend-shallow": "2.0.1",
+        "fill-range": "4.0.0",
+        "isobject": "3.0.1",
+        "repeat-element": "1.1.2",
+        "snapdragon": "0.8.2",
+        "snapdragon-node": "2.1.1",
+        "split-string": "3.1.0",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
+      }
+    },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
+    "cancel-token": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/cancel-token/-/cancel-token-0.1.1.tgz",
+      "integrity": "sha1-wYGXZ0uxyEwdaTPr8V2NWlznm08=",
+      "dev": true,
+      "requires": {
+        "@types/node": "4.2.23"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "4.2.23",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.23.tgz",
+          "integrity": "sha512-U6IchCNLRyswc9p6G6lxWlbE+KwAhZp6mGo6MD2yWpmFomhYmetK+c98OpKyvphNn04CU3aXeJrXdOqbXVTS/w==",
+          "dev": true
+        }
+      }
+    },
+    "chalk": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+      "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "3.2.1",
         "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "supports-color": "5.3.0"
+      }
+    },
+    "clang-format": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.2.3.tgz",
+      "integrity": "sha512-x90Hac4ERacGDcZSvHKK58Ga0STuMD+Doi5g0iG2zf7wlJef5Huvhs/3BvMRFxwRYyYSdl6mpQNrtfMxE8MQzw==",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "glob": "7.1.2",
+        "resolve": "1.7.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        }
+      }
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        }
       }
     },
     "clone": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "colors": {
@@ -338,16 +659,22 @@
       }
     },
     "command-line-usage": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz",
-      "integrity": "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-h17lBwC5bl5RdukPbXji75+cg2/Qbny6kGsmLoy34s9DNH90RwRvJKb+VU5j4YY9HzYl7twLaOWDJQ4b9U+p/Q==",
       "dev": true,
       "requires": {
-        "ansi-escape-sequences": "4.0.0",
         "array-back": "2.0.0",
-        "table-layout": "0.4.2",
+        "chalk": "2.3.2",
+        "table-layout": "0.4.3",
         "typical": "2.6.1"
       }
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -355,10 +682,16 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
     "core-js": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
+      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
       "dev": true
     },
     "cssbeautify": {
@@ -374,13 +707,19 @@
       "dev": true
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
     },
     "deep-extend": {
       "version": "0.5.0",
@@ -393,6 +732,47 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
     },
     "detect-indent": {
       "version": "4.0.0",
@@ -419,7 +799,7 @@
       "dev": true,
       "requires": {
         "@types/parse5": "2.2.34",
-        "clone": "2.1.1",
+        "clone": "2.1.2",
         "parse5": "4.0.0"
       }
     },
@@ -430,16 +810,16 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
-      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+      "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
       "dev": true,
       "requires": {
         "esprima": "3.1.3",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "optionator": "0.8.2",
-        "source-map": "0.5.7"
+        "source-map": "0.6.1"
       }
     },
     "esprima": {
@@ -460,17 +840,183 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "posix-character-classes": "0.1.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "requires": {
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "expand-brackets": "2.1.4",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
+    },
     "eyes": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
       "dev": true
     },
+    "fast-glob": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.0.tgz",
+      "integrity": "sha512-4F75PTznkNtSKs2pbhtBwRkw8sRwa7LfXx5XaQJOe4IQ6yTjceLDTwM5gj1s80R2t/5WeDC1gVfm3jLE+l39Tw==",
+      "dev": true,
+      "requires": {
+        "@mrmlnc/readdir-enhanced": "2.2.1",
+        "glob-parent": "3.1.0",
+        "is-glob": "4.0.0",
+        "merge2": "1.2.1",
+        "micromatch": "3.1.10"
+      }
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1",
+        "to-regex-range": "2.1.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
     },
     "find-replace": {
       "version": "2.0.1",
@@ -480,6 +1026,21 @@
       "requires": {
         "array-back": "2.0.0",
         "test-value": "3.0.0"
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "0.2.2"
       }
     },
     "fs-extra": {
@@ -499,6 +1060,12 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -513,10 +1080,37 @@
         "path-is-absolute": "1.0.1"
       }
     },
+    "glob-parent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "dev": true,
+      "requires": {
+        "is-glob": "3.1.0",
+        "path-dirname": "1.0.2"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        }
+      }
+    },
+    "glob-to-regexp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+      "dev": true
+    },
     "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
+      "integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA==",
       "dev": true
     },
     "graceful-fs": {
@@ -532,6 +1126,44 @@
       "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
       }
     },
     "indent": {
@@ -557,13 +1189,90 @@
       "dev": true
     },
     "invariant": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
         "loose-envify": "1.3.1"
       }
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -573,6 +1282,79 @@
       "requires": {
         "number-is-nan": "1.0.1"
       }
+    },
+    "is-glob": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+      "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "is-odd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+      "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        }
+      }
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      }
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
     },
     "isstream": {
       "version": "0.1.2",
@@ -602,9 +1384,15 @@
       }
     },
     "jsonschema": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.2.tgz",
-      "integrity": "sha512-iX5OFQ6yx9NgbHCwse51ohhKgLuLL7Z5cNOeZOPIlDUtAMrxlruHLzVZxbltdHE5mEDXN+75oFOwq6Gn0MZwsA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw==",
+      "dev": true
+    },
+    "kind-of": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
       "dev": true
     },
     "levn": {
@@ -635,6 +1423,12 @@
       "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
       "dev": true
     },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
@@ -642,6 +1436,48 @@
       "dev": true,
       "requires": {
         "js-tokens": "3.0.2"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "1.0.1"
+      }
+    },
+    "merge2": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.1.tgz",
+      "integrity": "sha512-wUqcG5pxrAcaFI1lkqkMnk3Q7nUxV/NWfpAFSeWUwG9TRODnBDCUHa75mi3o3vLWQ5N4CQERWCauSlP0I3ZqUg==",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "braces": "2.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "extglob": "2.0.4",
+        "fragment-cache": "0.2.1",
+        "kind-of": "6.0.2",
+        "nanomatch": "1.2.9",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "minimatch": {
@@ -662,17 +1498,107 @@
         "minimatch": "3.0.4"
       }
     },
+    "mixin-deep": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "nanomatch": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+      "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-odd": "2.0.0",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      }
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -703,10 +1629,34 @@
       "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
       "dev": true
     },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
     "plylog": {
@@ -716,8 +1666,8 @@
       "dev": true,
       "requires": {
         "@types/node": "4.2.23",
-        "@types/winston": "2.3.8",
-        "winston": "2.4.0"
+        "@types/winston": "2.3.9",
+        "winston": "2.4.1"
       },
       "dependencies": {
         "@types/node": {
@@ -729,9 +1679,9 @@
       }
     },
     "polymer-analyzer": {
-      "version": "3.0.0-pre.12",
-      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.12.tgz",
-      "integrity": "sha512-QQL70IC85hI6q9uQeresEMcT1Qf8YR/zDe1qG8WWeeFAZk8z0lmzUpsfcAWz+bM4wpDdXrtd4HitIs4p0CHl/w==",
+      "version": "3.0.0-pre.14",
+      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.14.tgz",
+      "integrity": "sha512-1Zh/smUWMrjBB7NFUk8i7EAnjO81PqhI0/RzMMy9VgAbPQ6jOROwFX71T02CgpkZYa0O66Ybl7G3+4+0S1aF1Q==",
       "dev": true,
       "requires": {
         "@types/babel-generator": "6.25.1",
@@ -743,27 +1693,34 @@
         "@types/clone": "0.1.30",
         "@types/cssbeautify": "0.3.1",
         "@types/doctrine": "0.0.1",
+        "@types/is-windows": "0.2.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "6.0.101",
+        "@types/node": "6.0.105",
         "@types/parse5": "2.2.34",
+        "@types/resolve": "0.0.6",
         "babel-generator": "6.26.1",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
+        "babel-traverse": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3",
+        "babylon": "7.0.0-beta.44",
+        "cancel-token": "0.1.1",
         "chalk": "1.1.3",
-        "clone": "2.1.1",
+        "clone": "2.1.2",
         "cssbeautify": "0.3.1",
         "doctrine": "2.1.0",
         "dom5": "3.0.0",
         "indent": "0.0.2",
-        "jsonschema": "1.2.2",
+        "is-windows": "1.0.2",
+        "jsonschema": "1.2.4",
         "minimatch": "3.0.4",
         "parse5": "4.0.0",
-        "polymer-project-config": "3.8.1",
+        "path-is-inside": "1.0.2",
+        "polymer-project-config": "3.13.0",
+        "resolve": "1.7.0",
         "shady-css-parser": "0.1.0",
         "stable": "0.1.6",
         "strip-indent": "2.0.0",
-        "vscode-uri": "1.0.1"
+        "vscode-uri": "1.0.3",
+        "whatwg-url": "6.4.0"
       },
       "dependencies": {
         "@types/doctrine": {
@@ -773,37 +1730,74 @@
           "dev": true
         },
         "@types/node": {
-          "version": "6.0.101",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.101.tgz",
-          "integrity": "sha512-IQ7V3D6+kK1DArTqTBrnl3M+YgJZLw8ta8w3Q9xjR79HaJzMAoTbZ8TNzUTztrkCKPTqIstE2exdbs1FzsYLUw==",
+          "version": "6.0.105",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.105.tgz",
+          "integrity": "sha512-fMIbw7iw91TSInS3b2DtDse5VaQEZqs0oTjvRNIFHnoHbnji+dLwpzL1L6dYGL39RzDNPHM/Off+VNcMk4ahwQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
     },
     "polymer-project-config": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-3.8.1.tgz",
-      "integrity": "sha512-MLvnM9gexFWg7nynY24eHZG6NLXocmk718sVds/sx2CAJ6iihhC0JMhhOIa6jnad9KQrHyGl/cs3mMRaaub5Fg==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-3.13.0.tgz",
+      "integrity": "sha512-0E1iSOpo2xFMvMomSDFl48J8IOUWmM+sfHGJSQSVfIu8GXDgz2TVraad+rEMZDbj8uxiRFvQZyouHhikxhVFpQ==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.101",
-        "jsonschema": "1.2.2",
+        "@types/node": "6.0.105",
+        "jsonschema": "1.2.4",
         "minimatch-all": "1.1.0",
         "plylog": "0.5.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.101",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.101.tgz",
-          "integrity": "sha512-IQ7V3D6+kK1DArTqTBrnl3M+YgJZLw8ta8w3Q9xjR79HaJzMAoTbZ8TNzUTztrkCKPTqIstE2exdbs1FzsYLUw==",
+          "version": "6.0.105",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.105.tgz",
+          "integrity": "sha512-fMIbw7iw91TSInS3b2DtDse5VaQEZqs0oTjvRNIFHnoHbnji+dLwpzL1L6dYGL39RzDNPHM/Off+VNcMk4ahwQ==",
           "dev": true
         }
       }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
       "dev": true
     },
     "reduce-flatten": {
@@ -818,6 +1812,28 @@
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
+      }
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
     "repeating": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
@@ -827,17 +1843,221 @@
         "is-finite": "1.0.2"
       }
     },
+    "resolve": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.0.tgz",
+      "integrity": "sha512-QdgZ5bjR1WAlpLaO5yHepFvC+o3rCr6wpfE2tpJNMkXdulf2jKomQBdNRQITF3ZKHNlT71syG98yQP03gasgnA==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "0.1.15"
+      }
+    },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
     "shady-css-parser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/shady-css-parser/-/shady-css-parser-0.1.0.tgz",
       "integrity": "sha512-irfJUUkEuDlNHKZNAp2r7zOyMlmbfVJ+kWSfjlCYYUx/7dJnANLCyTzQZsuxy5NJkvtNwSxY5Gj8MOlqXUQPyA==",
       "dev": true
     },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "requires": {
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.1",
+        "use": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "optional": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
+      "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+      "dev": true,
+      "requires": {
+        "atob": "2.1.0",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "3.0.2"
+      }
     },
     "stable": {
       "version": "0.1.6",
@@ -850,6 +2070,27 @@
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "dev": true
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        }
+      }
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -867,15 +2108,18 @@
       "dev": true
     },
     "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+      "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+      "dev": true,
+      "requires": {
+        "has-flag": "3.0.0"
+      }
     },
     "table-layout": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.2.tgz",
-      "integrity": "sha512-tygyl5+eSHj4chpq5Zfy6cpc7MOUBClAW9ozghFH7hg9bAUzShOYn+/vUzTRkKOSLJWKfgYtP2tAU2c0oAD8eg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.3.tgz",
+      "integrity": "sha512-MIhflPM38ejKrFwWwC3P9x3eHvMo5G5AmNo29Qtz2HpBl5KD2GCcmOErjgNtUQLv/qaqVDagfJY3rJLPDvEgLg==",
       "dev": true,
       "requires": {
         "array-back": "2.0.0",
@@ -901,6 +2145,57 @@
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "2.1.0"
+      }
+    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -922,22 +2217,141 @@
       "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
       "dev": true
     },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
+          }
+        }
+      }
+    },
     "universalify": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
       "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
       "dev": true
     },
-    "vscode-uri": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.1.tgz",
-      "integrity": "sha1-Eahr7+rDxKo+wIYjZRo8gabQu8g=",
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        }
+      }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
+    "use": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+      "dev": true,
+      "requires": {
+        "kind-of": "6.0.2"
+      }
+    },
+    "vscode-uri": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.3.tgz",
+      "integrity": "sha1-Yxvb9xbcyrDmUpGo3CXCMjIIWlI=",
+      "dev": true
+    },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
+    "webmat": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/webmat/-/webmat-0.2.0.tgz",
+      "integrity": "sha512-xf2iHrssbbTofFwxvrdtgSxILQ8ledlpeDc76fNkTEL76gGnxCB/YA69UF498+UPfYIDvVnk9Qt2E7MJOApacA==",
+      "dev": true,
+      "requires": {
+        "clang-format": "1.2.3",
+        "dom5": "3.0.0",
+        "fast-glob": "2.2.0",
+        "parse5": "4.0.0"
+      }
+    },
+    "whatwg-url": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
+      "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "4.7.0",
+        "tr46": "1.0.1",
+        "webidl-conversions": "4.0.2"
+      }
+    },
     "winston": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
-      "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.1.tgz",
+      "integrity": "sha512-k/+Dkzd39ZdyJHYkuaYmf4ff+7j+sCIy73UCOWHYA67/WXU+FF/Y6PF28j+Vy7qNRPHWO+dR+/+zkoQWPimPqg==",
       "dev": true,
       "requires": {
         "async": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "license": "BSD-3-Clause",
   "devDependencies": {
     "@polymer/gen-typescript-declarations": "^1.2.0",
-    "bower": "^1.8.0"
+    "bower": "^1.8.0",
+    "webmat": "^0.2.0"
   },
   "scripts": {
-    "update-types": "bower install && gen-typescript-declarations --deleteExisting --outDir ."
+    "update-types": "bower install && gen-typescript-declarations --deleteExisting --outDir .",
+    "format": "webmat && npm run update-types"
   }
 }

--- a/platinum-sw-cache.d.ts
+++ b/platinum-sw-cache.d.ts
@@ -11,54 +11,58 @@
 /// <reference path="../polymer/types/polymer.d.ts" />
 
 /**
- * The `<platinum-sw-cache>` element makes it easy to precache specific resources, perform runtime
- * caching, and serve your cached resources when a network is unavailable.
- * Under the hood, the [sw-toolbox](https://github.com/googlechrome/sw-toolbox) library is used
- * for all the caching and request handling logic.
- * `<platinum-sw-cache>` needs to be a child element of `<platinum-sw-register>`.
- * A simple, yet useful configuration is
+ * The `<platinum-sw-cache>` element makes it easy to precache specific
+ * resources, perform runtime caching, and serve your cached resources when a
+ * network is unavailable. Under the hood, the
+ * [sw-toolbox](https://github.com/googlechrome/sw-toolbox) library is used for
+ * all the caching and request handling logic.
+ * `<platinum-sw-cache>` needs to be a child element of
+ * `<platinum-sw-register>`. A simple, yet useful configuration is
  *
  *     <platinum-sw-register auto-register>
  *       <platinum-sw-cache></platinum-sw-cache>
  *     </platinum-sw-register>
  *
- * This is enough to have all of the resources your site uses cached at runtime, both local and
- * cross-origin.
- * (It uses the default `defaultCacheStrategy` of "networkFirst".)
- * When there's a network available, visits to your site will go against the network copy of the
- * resources, but if someone visits your site when they're offline, all the cached resources will
- * be used.
+ * This is enough to have all of the resources your site uses cached at runtime,
+ * both local and cross-origin. (It uses the default `defaultCacheStrategy` of
+ * "networkFirst".) When there's a network available, visits to your site will
+ * go against the network copy of the resources, but if someone visits your site
+ * when they're offline, all the cached resources will be used.
  */
 interface PlatinumSwCacheElement extends Polymer.Element {
 
   /**
-   * Used to configure `<platinum-sw-precache>` behavior via a JSON file instead of via
-   * attributes. This can come in handy when the configuration (e.g. which files to precache)
-   * depends on the results of a build script.
+   * Used to configure `<platinum-sw-precache>` behavior via a JSON file
+   * instead of via attributes. This can come in handy when the configuration
+   * (e.g. which files to precache) depends on the results of a build script.
    *
-   * If configuration for the same properties are provided in both the JSON file and via the
-   * element's attributes, then in general the JSON file's values take precedence. The one
-   * exception is the `precache` property. Any values in the element's `precache` attribute will
-   * be concatenated with the values in the JSON file's `precache` property and the set of files
+   * If configuration for the same properties are provided in both the JSON
+   * file and via the element's attributes, then in general the JSON file's
+   * values take precedence. The one exception is the `precache` property. Any
+   * values in the element's `precache` attribute will be concatenated with
+   * the values in the JSON file's `precache` property and the set of files
    * that are precached will be the union of the two.
    *
-   * There's one additional option, `precacheFingerprint`, that can be set in the JSON. If using
-   * a build script that might output a large number of files to precache, its recommended
-   * that your build script generate a unique "fingerprint" of the files. Any changes to the
-   * `precacheFingerprint` value will result in the underlying service worker kicking off the
-   * process of caching the files listed in `precache`.
-   * While there are a few different strategies for generating an appropriate
-   * `precacheFingerprint` value, a process that makes sense is to use a stable hash of the
-   * serialized `precache` array. That way, any changes to the list of files in `precache`
-   * will result in a new `precacheFingerprint` value.
-   * If your build script is Node.js based, one way to generate this hash is:
+   * There's one additional option, `precacheFingerprint`, that can be set in
+   * the JSON. If using a build script that might output a large number of
+   * files to precache, its recommended that your build script generate a
+   * unique "fingerprint" of the files. Any changes to the
+   * `precacheFingerprint` value will result in the underlying service worker
+   * kicking off the process of caching the files listed in `precache`. While
+   * there are a few different strategies for generating an appropriate
+   * `precacheFingerprint` value, a process that makes sense is to use a
+   * stable hash of the serialized `precache` array. That way, any changes to
+   * the list of files in `precache` will result in a new
+   * `precacheFingerprint` value. If your build script is Node.js based, one
+   * way to generate this hash is:
    *
    *     var md5 = require('crypto').createHash('md5');
    *     md5.update(JSON.stringify(precache));
    *     var precacheFingerprint = md5.digest('hex');
    *
    * Alternatively, you could use something like the
-   * [SHA-1 signature](http://stackoverflow.com/questions/1161869/how-to-get-sha-of-the-latest-commit-from-remote-git-repository)
+   * [SHA-1
+   * signature](http://stackoverflow.com/questions/1161869/how-to-get-sha-of-the-latest-commit-from-remote-git-repository)
    * of your latest `git` commit for the `precacheFingerprint` value.
    *
    * An example file may look like:
@@ -82,41 +86,47 @@ interface PlatinumSwCacheElement extends Polymer.Element {
    * [`toolbox.options.cacheName`](https://github.com/GoogleChrome/sw-toolbox/blob/8763dcc9fbc9352d58f184050e2131c42f7b6d68/lib/options.js#L28)
    * will be used.
    *
-   * The `cacheId` is combined with the service worker's scope to construct the cache name, so
-   * two `<platinum-sw-cache>` elements that are associated with different scopes will use
-   * different caches.
+   * The `cacheId` is combined with the service worker's scope to construct
+   * the cache name, so two `<platinum-sw-cache>` elements that are associated
+   * with different scopes will use different caches.
    */
   cacheId: string|null|undefined;
 
   /**
-   * The caching strategy used for all requests, both for local and cross-origin resources.
+   * The caching strategy used for all requests, both for local and
+   * cross-origin resources.
    *
-   * For a list of strategies, see the [`sw-toolbox` documentation](https://github.com/GoogleChrome/sw-toolbox#built-in-handlers).
+   * For a list of strategies, see the [`sw-toolbox`
+   * documentation](https://github.com/GoogleChrome/sw-toolbox#built-in-handlers).
    * Specify a strategy as a string, without the "toolbox" prefix. E.g., for
    * `toolbox.networkFirst`, set `defaultCacheStrategy` to "networkFirst".
    *
-   * Note that the "cacheFirst" and "cacheOnly" strategies are not recommended, and may be
-   * explicitly prevented in a future release. More information can be found at
+   * Note that the "cacheFirst" and "cacheOnly" strategies are not
+   * recommended, and may be explicitly prevented in a future release. More
+   * information can be found at
    * https://github.com/PolymerElements/platinum-sw#cacheonly--cachefirst-defaultcachestrategy-considered-harmful
    */
   defaultCacheStrategy: string|null|undefined;
 
   /**
-   * If set to true, this element will not set up service worker caching. This is useful to
-   * conditionally enable or disable caching depending on the build environment.
+   * If set to true, this element will not set up service worker caching. This
+   * is useful to conditionally enable or disable caching depending on the
+   * build environment.
    */
   disabled: boolean|null|undefined;
 
   /**
-   * Used to provide a list of URLs that are always precached as soon as the service worker is
-   * installed. Corresponds to  [`sw-toolbox`'s `precache()` method](https://github.com/GoogleChrome/sw-toolbox#toolboxprecachearrayofurls).
+   * Used to provide a list of URLs that are always precached as soon as the
+   * service worker is installed. Corresponds to  [`sw-toolbox`'s `precache()`
+   * method](https://github.com/GoogleChrome/sw-toolbox#toolboxprecachearrayofurls).
    *
-   * This is useful for URLs that that wouldn't necessarily be picked up by runtime caching,
-   * i.e. a list of resources that are needed by one of the subpages of your site, or a list of
-   * resources that are only loaded via user interaction.
+   * This is useful for URLs that that wouldn't necessarily be picked up by
+   * runtime caching, i.e. a list of resources that are needed by one of the
+   * subpages of your site, or a list of resources that are only loaded via
+   * user interaction.
    *
-   * `precache` can be used in conjunction with `cacheConfigFile`, and the two arrays will be
-   * concatenated.
+   * `precache` can be used in conjunction with `cacheConfigFile`, and the two
+   * arrays will be concatenated.
    */
   precache: any[]|null|undefined;
   _getParameters(baseURI: any): any;

--- a/platinum-sw-cache.html
+++ b/platinum-sw-cache.html
@@ -11,23 +11,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
   /**
-   * The `<platinum-sw-cache>` element makes it easy to precache specific resources, perform runtime
-   * caching, and serve your cached resources when a network is unavailable.
-   * Under the hood, the [sw-toolbox](https://github.com/googlechrome/sw-toolbox) library is used
-   * for all the caching and request handling logic.
-   * `<platinum-sw-cache>` needs to be a child element of `<platinum-sw-register>`.
-   * A simple, yet useful configuration is
+   * The `<platinum-sw-cache>` element makes it easy to precache specific
+   * resources, perform runtime caching, and serve your cached resources when a
+   * network is unavailable. Under the hood, the
+   * [sw-toolbox](https://github.com/googlechrome/sw-toolbox) library is used for
+   * all the caching and request handling logic.
+   * `<platinum-sw-cache>` needs to be a child element of
+   * `<platinum-sw-register>`. A simple, yet useful configuration is
    *
    *     <platinum-sw-register auto-register>
    *       <platinum-sw-cache></platinum-sw-cache>
    *     </platinum-sw-register>
    *
-   * This is enough to have all of the resources your site uses cached at runtime, both local and
-   * cross-origin.
-   * (It uses the default `defaultCacheStrategy` of "networkFirst".)
-   * When there's a network available, visits to your site will go against the network copy of the
-   * resources, but if someone visits your site when they're offline, all the cached resources will
-   * be used.
+   * This is enough to have all of the resources your site uses cached at runtime,
+   * both local and cross-origin. (It uses the default `defaultCacheStrategy` of
+   * "networkFirst".) When there's a network available, visits to your site will
+   * go against the network copy of the resources, but if someone visits your site
+   * when they're offline, all the cached resources will be used.
    *
    * @demo demo/index.html An offline-capable eReader demo.
    */
@@ -36,33 +36,37 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     properties: {
       /**
-       * Used to configure `<platinum-sw-precache>` behavior via a JSON file instead of via
-       * attributes. This can come in handy when the configuration (e.g. which files to precache)
-       * depends on the results of a build script.
+       * Used to configure `<platinum-sw-precache>` behavior via a JSON file
+       * instead of via attributes. This can come in handy when the configuration
+       * (e.g. which files to precache) depends on the results of a build script.
        *
-       * If configuration for the same properties are provided in both the JSON file and via the
-       * element's attributes, then in general the JSON file's values take precedence. The one
-       * exception is the `precache` property. Any values in the element's `precache` attribute will
-       * be concatenated with the values in the JSON file's `precache` property and the set of files
+       * If configuration for the same properties are provided in both the JSON
+       * file and via the element's attributes, then in general the JSON file's
+       * values take precedence. The one exception is the `precache` property. Any
+       * values in the element's `precache` attribute will be concatenated with
+       * the values in the JSON file's `precache` property and the set of files
        * that are precached will be the union of the two.
        *
-       * There's one additional option, `precacheFingerprint`, that can be set in the JSON. If using
-       * a build script that might output a large number of files to precache, its recommended
-       * that your build script generate a unique "fingerprint" of the files. Any changes to the
-       * `precacheFingerprint` value will result in the underlying service worker kicking off the
-       * process of caching the files listed in `precache`.
-       * While there are a few different strategies for generating an appropriate
-       * `precacheFingerprint` value, a process that makes sense is to use a stable hash of the
-       * serialized `precache` array. That way, any changes to the list of files in `precache`
-       * will result in a new `precacheFingerprint` value.
-       * If your build script is Node.js based, one way to generate this hash is:
+       * There's one additional option, `precacheFingerprint`, that can be set in
+       * the JSON. If using a build script that might output a large number of
+       * files to precache, its recommended that your build script generate a
+       * unique "fingerprint" of the files. Any changes to the
+       * `precacheFingerprint` value will result in the underlying service worker
+       * kicking off the process of caching the files listed in `precache`. While
+       * there are a few different strategies for generating an appropriate
+       * `precacheFingerprint` value, a process that makes sense is to use a
+       * stable hash of the serialized `precache` array. That way, any changes to
+       * the list of files in `precache` will result in a new
+       * `precacheFingerprint` value. If your build script is Node.js based, one
+       * way to generate this hash is:
        *
        *     var md5 = require('crypto').createHash('md5');
        *     md5.update(JSON.stringify(precache));
        *     var precacheFingerprint = md5.digest('hex');
        *
        * Alternatively, you could use something like the
-       * [SHA-1 signature](http://stackoverflow.com/questions/1161869/how-to-get-sha-of-the-latest-commit-from-remote-git-repository)
+       * [SHA-1
+       * signature](http://stackoverflow.com/questions/1161869/how-to-get-sha-of-the-latest-commit-from-remote-git-repository)
        * of your latest `git` commit for the `precacheFingerprint` value.
        *
        * An example file may look like:
@@ -86,100 +90,110 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * [`toolbox.options.cacheName`](https://github.com/GoogleChrome/sw-toolbox/blob/8763dcc9fbc9352d58f184050e2131c42f7b6d68/lib/options.js#L28)
        * will be used.
        *
-       * The `cacheId` is combined with the service worker's scope to construct the cache name, so
-       * two `<platinum-sw-cache>` elements that are associated with different scopes will use
-       * different caches.
+       * The `cacheId` is combined with the service worker's scope to construct
+       * the cache name, so two `<platinum-sw-cache>` elements that are associated
+       * with different scopes will use different caches.
        */
       cacheId: String,
 
       /**
-       * The caching strategy used for all requests, both for local and cross-origin resources.
+       * The caching strategy used for all requests, both for local and
+       * cross-origin resources.
        *
-       * For a list of strategies, see the [`sw-toolbox` documentation](https://github.com/GoogleChrome/sw-toolbox#built-in-handlers).
+       * For a list of strategies, see the [`sw-toolbox`
+       * documentation](https://github.com/GoogleChrome/sw-toolbox#built-in-handlers).
        * Specify a strategy as a string, without the "toolbox" prefix. E.g., for
        * `toolbox.networkFirst`, set `defaultCacheStrategy` to "networkFirst".
        *
-       * Note that the "cacheFirst" and "cacheOnly" strategies are not recommended, and may be
-       * explicitly prevented in a future release. More information can be found at
+       * Note that the "cacheFirst" and "cacheOnly" strategies are not
+       * recommended, and may be explicitly prevented in a future release. More
+       * information can be found at
        * https://github.com/PolymerElements/platinum-sw#cacheonly--cachefirst-defaultcachestrategy-considered-harmful
        *
        * @see {@link https://github.com/GoogleChrome/sw-toolbox#built-in-handlers}
        */
-      defaultCacheStrategy: {
-        type: String,
-        value: 'networkFirst'
-      },
+      defaultCacheStrategy: {type: String, value: 'networkFirst'},
 
       /**
-       * If set to true, this element will not set up service worker caching. This is useful to
-       * conditionally enable or disable caching depending on the build environment.
+       * If set to true, this element will not set up service worker caching. This
+       * is useful to conditionally enable or disable caching depending on the
+       * build environment.
        */
-      disabled: {
-        type: Boolean,
-        value: false
-      },
+      disabled: {type: Boolean, value: false},
 
       /**
-       * Used to provide a list of URLs that are always precached as soon as the service worker is
-       * installed. Corresponds to  [`sw-toolbox`'s `precache()` method](https://github.com/GoogleChrome/sw-toolbox#toolboxprecachearrayofurls).
+       * Used to provide a list of URLs that are always precached as soon as the
+       * service worker is installed. Corresponds to  [`sw-toolbox`'s `precache()`
+       * method](https://github.com/GoogleChrome/sw-toolbox#toolboxprecachearrayofurls).
        *
-       * This is useful for URLs that that wouldn't necessarily be picked up by runtime caching,
-       * i.e. a list of resources that are needed by one of the subpages of your site, or a list of
-       * resources that are only loaded via user interaction.
+       * This is useful for URLs that that wouldn't necessarily be picked up by
+       * runtime caching, i.e. a list of resources that are needed by one of the
+       * subpages of your site, or a list of resources that are only loaded via
+       * user interaction.
        *
-       * `precache` can be used in conjunction with `cacheConfigFile`, and the two arrays will be
-       * concatenated.
+       * `precache` can be used in conjunction with `cacheConfigFile`, and the two
+       * arrays will be concatenated.
        *
        * @see {@link https://github.com/GoogleChrome/sw-toolbox#toolboxprecachearrayofurls}
        */
       precache: {
         type: Array,
-        value: function() { return []; }
+        value: function() {
+          return [];
+        }
       }
     },
 
     _getParameters: function(baseURI) {
       return new Promise(function(resolve) {
         var params = {
-          importscriptLate: new URL('bootstrap/sw-toolbox-setup.js', baseURI).href,
+          importscriptLate:
+              new URL('bootstrap/sw-toolbox-setup.js', baseURI).href,
           defaultCacheStrategy: this.defaultCacheStrategy,
           precache: this.precache
         };
 
         if (this.cacheConfigFile) {
           params.cacheConfigFile = this.cacheConfigFile;
-          window.fetch(this.cacheConfigFile).then(function(response) {
-            if (!response.ok) {
-              throw Error('unable to load ' + this.cacheConfigFile);
-            }
-            return response.json();
-          }.bind(this)).then(function(config) {
-            this.disabled = config.disabled;
-            if (this.disabled) {
-              // Use an empty set of parameters to effectively disable caching.
-              params = {};
-            } else {
-              // If there's a hash of the list of files to precache provided in the config file,
-              // then copy that over to the params that will be used to construct the service worker
-              // URL. This works around the issue where a potentially large number of precache
-              // files could result in a longer URL than a browser will allow.
-              // The actual list of files to precache (in config.precache) will be dealt by the
-              // service worker during the install phase, so we can ignore it here.
-              // See https://github.com/PolymerElements/platinum-sw/issues/53
-              if (config.precacheFingerprint) {
-                params.precacheFingerprint = config.precacheFingerprint;
-              } else {
-                params.precache = params.precache.concat(config.precache);
-              }
-              params.cacheId = config.cacheId || params.cacheId;
-              params.defaultCacheStrategy = config.defaultCacheStrategy ||
-                params.defaultCacheStrategy;
-            }
-          }.bind(this)).catch(function(error) {
-            Polymer.Base._info('Skipping precaching: ' + error.message);
-          }).then(function() {
-            resolve(params);
-          });
+          window.fetch(this.cacheConfigFile)
+              .then(function(response) {
+                if (!response.ok) {
+                  throw Error('unable to load ' + this.cacheConfigFile);
+                }
+                return response.json();
+              }.bind(this))
+              .then(function(config) {
+                this.disabled = config.disabled;
+                if (this.disabled) {
+                  // Use an empty set of parameters to effectively disable
+                  // caching.
+                  params = {};
+                } else {
+                  // If there's a hash of the list of files to precache provided
+                  // in the config file, then copy that over to the params that
+                  // will be used to construct the service worker URL. This works
+                  // around the issue where a potentially large number of precache
+                  // files could result in a longer URL than a browser will allow.
+                  // The actual list of files to precache (in config.precache)
+                  // will be dealt by the service worker during the install phase,
+                  // so we can ignore it here. See
+                  // https://github.com/PolymerElements/platinum-sw/issues/53
+                  if (config.precacheFingerprint) {
+                    params.precacheFingerprint = config.precacheFingerprint;
+                  } else {
+                    params.precache = params.precache.concat(config.precache);
+                  }
+                  params.cacheId = config.cacheId || params.cacheId;
+                  params.defaultCacheStrategy =
+                      config.defaultCacheStrategy || params.defaultCacheStrategy;
+                }
+              }.bind(this))
+              .catch(function(error) {
+                Polymer.Base._info('Skipping precaching: ' + error.message);
+              })
+              .then(function() {
+                resolve(params);
+              });
         } else {
           resolve(params);
         }

--- a/platinum-sw-fetch.d.ts
+++ b/platinum-sw-fetch.d.ts
@@ -11,103 +11,122 @@
 /// <reference path="../polymer/types/polymer.d.ts" />
 
 /**
- * The `<platinum-sw-fetch>` element creates custom [`fetch` event](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#fetch-event-section)
+ * The `<platinum-sw-fetch>` element creates custom [`fetch`
+ * event](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#fetch-event-section)
  * handlers for given URL patterns. Possible use cases include:
  *
  * - Using a special caching strategy for specific URLs.
- * - Returning static "fallback" responses instead of network errors when a remote API
- * is unavailable.
+ * - Returning static "fallback" responses instead of network errors when a
+ * remote API is unavailable.
  *
- * In short, any scenario in which you'd like a service worker to intercept network
- * requests and provide custom response handling.
+ * In short, any scenario in which you'd like a service worker to intercept
+ * network requests and provide custom response handling.
  *
- * If you'd like a single caching policy applied to all same-origin requests, then an alternative
- * to using `<platinum-sw-fetch>` is to use `<platinum-sw-cache>` with the `defaultCacheStategy`
- * property set.
+ * If you'd like a single caching policy applied to all same-origin requests,
+ * then an alternative to using `<platinum-sw-fetch>` is to use
+ * `<platinum-sw-cache>` with the `defaultCacheStategy` property set.
  *
- * Under the hood, the [sw-toolbox](https://github.com/googlechrome/sw-toolbox) library is used
- * for all the request handling logic.
+ * Under the hood, the [sw-toolbox](https://github.com/googlechrome/sw-toolbox)
+ * library is used for all the request handling logic.
  *
- * `<platinum-sw-fetch>` needs to be a child element of `<platinum-sw-register>`.
+ * `<platinum-sw-fetch>` needs to be a child element of
+ * `<platinum-sw-register>`.
  *
  * An example configuration is:
  *
  *     <platinum-sw-register auto-register>
- *       <platinum-sw-import-script href="custom-fetch-handler.js"></platinum-sw-import-script>
+ *       <platinum-sw-import-script
+ * href="custom-fetch-handler.js"></platinum-sw-import-script>
  *       <platinum-sw-fetch handler="customFetchHandler"
  *                          path="/(.*)/customFetch"></platinum-sw-fetch>
  *     </platinum-sw-register>
  *
- * This implies that there's a `custom-fetch-handler.js` file in the same directory as the current
- * page, which defines a `sw-toolbox` compliant
- * [request handler](https://github.com/googlechrome/sw-toolbox#request-handlers) named
- * `customFetchHandler`. This definition is imported using `<platinum-sw-import-script>`. The
- * `<platinum-sw-fetch>` element takes care of mapping which request paths are handled by
- * `customFetchHandler`.
+ * This implies that there's a `custom-fetch-handler.js` file in the same
+ * directory as the current page, which defines a `sw-toolbox` compliant
+ * [request
+ * handler](https://github.com/googlechrome/sw-toolbox#request-handlers) named
+ * `customFetchHandler`. This definition is imported using
+ * `<platinum-sw-import-script>`. The
+ * `<platinum-sw-fetch>` element takes care of mapping which request paths are
+ * handled by `customFetchHandler`.
  *
  * Anything not matching the `path` pattern is ignored by `<platinum-sw-fetch>`,
- * and it's possible to have multiple `<platinum-sw-fetch>` elements that each define different
- * paths and different handlers. The path matching is performed top-down, starting with the first
+ * and it's possible to have multiple `<platinum-sw-fetch>` elements that each
+ * define different paths and different handlers. The path matching is performed
+ * top-down, starting with the first
  * `<platinum-sw-fetch>` element.
  *
- * The `path` will, by default, only match same-origin requests. If you'd like to define a custom
- * handler for requests on a specific cross-origin domain, you must use the `origin` parameter
- * in conjunction with `path` to match the domains you'd like to handle.
+ * The `path` will, by default, only match same-origin requests. If you'd like
+ * to define a custom handler for requests on a specific cross-origin domain,
+ * you must use the `origin` parameter in conjunction with `path` to match the
+ * domains you'd like to handle.
  */
 interface PlatinumSwFetchElement extends Polymer.Element {
 
   /**
-   * The name of the request handler to use. This should be a `sw-toolbox`-style
-   * [request handler](https://github.com/googlechrome/sw-toolbox#request-handlers).
+   * The name of the request handler to use. This should be a
+   * `sw-toolbox`-style [request
+   * handler](https://github.com/googlechrome/sw-toolbox#request-handlers).
    *
-   * `handler` is a `String`, not a `function`, so you're providing the name of a function, not
-   * the function itself. It can be a function defined in the
-   * [`toolbox` scope](https://github.com/googlechrome/sw-toolbox#built-in-handlers)
-   * (e.g. 'networkFirst', 'fastest', 'networkOnly', etc.) or a function defined in the
+   * `handler` is a `String`, not a `function`, so you're providing the name
+   * of a function, not the function itself. It can be a function defined in
+   * the
+   * [`toolbox`
+   * scope](https://github.com/googlechrome/sw-toolbox#built-in-handlers) (e.g.
+   * 'networkFirst', 'fastest', 'networkOnly', etc.) or a function defined in
+   * the
    * [`ServiceWorkerGlobalScope`](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-global-scope),
-   * like a function that is defined in a file that's imported via `platinum-sw-import-script`.
+   * like a function that is defined in a file that's imported via
+   * `platinum-sw-import-script`.
    * *
    */
   handler: string|null|undefined;
 
   /**
-   * By default, `path` will only match URLs under the current host (i.e. same-origin requests).
-   * If you'd like to apply `handler` to cross-origin requests, then use `origin` to specify
-   * which hosts will match. Setting `origin` is optional.
+   * By default, `path` will only match URLs under the current host (i.e.
+   * same-origin requests). If you'd like to apply `handler` to cross-origin
+   * requests, then use `origin` to specify which hosts will match. Setting
+   * `origin` is optional.
    *
    * `origin` is a `String`, but it is used internally to construct a
-   * [`RegExp` object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions),
+   * [`RegExp`
+   * object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions),
    * which is used for the matching.
    *
-   * Note that the `origin` value will be matched against the full domain name and the protocol.
-   * If you want to match  'http' and 'https', then use 'https?://' at the start of your string.
+   * Note that the `origin` value will be matched against the full domain name
+   * and the protocol. If you want to match  'http' and 'https', then use
+   * 'https?://' at the start of your string.
    *
    * Some examples:
-   * - `origin="https?://.+\.google\.com"` → a RegExp that matches `http` or `https` requests
-   *   made to any domain that ends in `.google.com`.
-   * - `origin="https://www\.example\.com" → a RegExp that will only match `https` requests to
-   *   one domain, `www.example.com`.
+   * - `origin="https?://.+\.google\.com"` → a RegExp that matches `http` or
+   * `https` requests made to any domain that ends in `.google.com`.
+   * - `origin="https://www\.example\.com" → a RegExp that will only match
+   * `https` requests to one domain, `www.example.com`.
    */
   origin: string|null|undefined;
 
   /**
    * URLs with paths matching `path` will have `handler` applied to them.
    *
-   * By default, `path` will only match same-origin URLs. If you'd like it to match
-   * cross-origin URLs, use `path` in conjunction with `origin`.
+   * By default, `path` will only match same-origin URLs. If you'd like it to
+   * match cross-origin URLs, use `path` in conjunction with `origin`.
    *
    * As explained in the
-   * [`sw-toolbox` docs](https://github.com/googlechrome/sw-toolbox#toolboxrouterheadurlpattern-handler-options),
-   * the URL path matching is done using the [`path-to-regexp`](https://github.com/pillarjs/path-to-regexp)
-   * module, which is the same logic used in [Express-style routing](http://expressjs.com/guide/routing.html).
+   * [`sw-toolbox`
+   * docs](https://github.com/googlechrome/sw-toolbox#toolboxrouterheadurlpattern-handler-options),
+   * the URL path matching is done using the
+   * [`path-to-regexp`](https://github.com/pillarjs/path-to-regexp) module,
+   * which is the same logic used in [Express-style
+   * routing](http://expressjs.com/guide/routing.html).
    *
-   * In practice, you need to always use '/' as the first character of your `path`, and then
-   * can use '(.*)' as a wildcard.
+   * In practice, you need to always use '/' as the first character of your
+   * `path`, and then can use '(.*)' as a wildcard.
    *
    * Some examples:
-   * - `path="/(.*)/customFetch"` → matches any path that ends with '/customFetch'.
-   * - `path="/customFetch(.*)"` → matches any path that starts with '/customFetch', optionally
-   *   followed by other characters.
+   * - `path="/(.*)/customFetch"` → matches any path that ends with
+   * '/customFetch'.
+   * - `path="/customFetch(.*)"` → matches any path that starts with
+   * '/customFetch', optionally followed by other characters.
    */
   path: string|null|undefined;
   _getParameters(baseURI: any): any;

--- a/platinum-sw-fetch.html
+++ b/platinum-sw-fetch.html
@@ -11,85 +11,100 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
   /**
-   * The `<platinum-sw-fetch>` element creates custom [`fetch` event](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#fetch-event-section)
+   * The `<platinum-sw-fetch>` element creates custom [`fetch`
+   * event](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#fetch-event-section)
    * handlers for given URL patterns. Possible use cases include:
    *
    * - Using a special caching strategy for specific URLs.
-   * - Returning static "fallback" responses instead of network errors when a remote API
-   * is unavailable.
+   * - Returning static "fallback" responses instead of network errors when a
+   * remote API is unavailable.
    *
-   * In short, any scenario in which you'd like a service worker to intercept network
-   * requests and provide custom response handling.
+   * In short, any scenario in which you'd like a service worker to intercept
+   * network requests and provide custom response handling.
    *
-   * If you'd like a single caching policy applied to all same-origin requests, then an alternative
-   * to using `<platinum-sw-fetch>` is to use `<platinum-sw-cache>` with the `defaultCacheStategy`
-   * property set.
+   * If you'd like a single caching policy applied to all same-origin requests,
+   * then an alternative to using `<platinum-sw-fetch>` is to use
+   * `<platinum-sw-cache>` with the `defaultCacheStategy` property set.
    *
-   * Under the hood, the [sw-toolbox](https://github.com/googlechrome/sw-toolbox) library is used
-   * for all the request handling logic.
+   * Under the hood, the [sw-toolbox](https://github.com/googlechrome/sw-toolbox)
+   * library is used for all the request handling logic.
    *
-   * `<platinum-sw-fetch>` needs to be a child element of `<platinum-sw-register>`.
+   * `<platinum-sw-fetch>` needs to be a child element of
+   * `<platinum-sw-register>`.
    *
    * An example configuration is:
    *
    *     <platinum-sw-register auto-register>
-   *       <platinum-sw-import-script href="custom-fetch-handler.js"></platinum-sw-import-script>
+   *       <platinum-sw-import-script
+   * href="custom-fetch-handler.js"></platinum-sw-import-script>
    *       <platinum-sw-fetch handler="customFetchHandler"
    *                          path="/(.*)/customFetch"></platinum-sw-fetch>
    *     </platinum-sw-register>
    *
-   * This implies that there's a `custom-fetch-handler.js` file in the same directory as the current
-   * page, which defines a `sw-toolbox` compliant
-   * [request handler](https://github.com/googlechrome/sw-toolbox#request-handlers) named
-   * `customFetchHandler`. This definition is imported using `<platinum-sw-import-script>`. The
-   * `<platinum-sw-fetch>` element takes care of mapping which request paths are handled by
-   * `customFetchHandler`.
+   * This implies that there's a `custom-fetch-handler.js` file in the same
+   * directory as the current page, which defines a `sw-toolbox` compliant
+   * [request
+   * handler](https://github.com/googlechrome/sw-toolbox#request-handlers) named
+   * `customFetchHandler`. This definition is imported using
+   * `<platinum-sw-import-script>`. The
+   * `<platinum-sw-fetch>` element takes care of mapping which request paths are
+   * handled by `customFetchHandler`.
    *
    * Anything not matching the `path` pattern is ignored by `<platinum-sw-fetch>`,
-   * and it's possible to have multiple `<platinum-sw-fetch>` elements that each define different
-   * paths and different handlers. The path matching is performed top-down, starting with the first
+   * and it's possible to have multiple `<platinum-sw-fetch>` elements that each
+   * define different paths and different handlers. The path matching is performed
+   * top-down, starting with the first
    * `<platinum-sw-fetch>` element.
    *
-   * The `path` will, by default, only match same-origin requests. If you'd like to define a custom
-   * handler for requests on a specific cross-origin domain, you must use the `origin` parameter
-   * in conjunction with `path` to match the domains you'd like to handle.
+   * The `path` will, by default, only match same-origin requests. If you'd like
+   * to define a custom handler for requests on a specific cross-origin domain,
+   * you must use the `origin` parameter in conjunction with `path` to match the
+   * domains you'd like to handle.
    */
   Polymer({
     is: 'platinum-sw-fetch',
 
     properties: {
       /**
-       * The name of the request handler to use. This should be a `sw-toolbox`-style
-       * [request handler](https://github.com/googlechrome/sw-toolbox#request-handlers).
+       * The name of the request handler to use. This should be a
+       *`sw-toolbox`-style [request
+       *handler](https://github.com/googlechrome/sw-toolbox#request-handlers).
        *
-       * `handler` is a `String`, not a `function`, so you're providing the name of a function, not
-       * the function itself. It can be a function defined in the
-       * [`toolbox` scope](https://github.com/googlechrome/sw-toolbox#built-in-handlers)
-       * (e.g. 'networkFirst', 'fastest', 'networkOnly', etc.) or a function defined in the
+       * `handler` is a `String`, not a `function`, so you're providing the name
+       *of a function, not the function itself. It can be a function defined in
+       *the
+       * [`toolbox`
+       *scope](https://github.com/googlechrome/sw-toolbox#built-in-handlers) (e.g.
+       *'networkFirst', 'fastest', 'networkOnly', etc.) or a function defined in
+       *the
        * [`ServiceWorkerGlobalScope`](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-global-scope),
-       * like a function that is defined in a file that's imported via `platinum-sw-import-script`.
+       * like a function that is defined in a file that's imported via
+       *`platinum-sw-import-script`.
        **
        * @see {@link https://github.com/GoogleChrome/sw-toolbox#built-in-handlers}
        */
       handler: String,
 
       /**
-       * By default, `path` will only match URLs under the current host (i.e. same-origin requests).
-       * If you'd like to apply `handler` to cross-origin requests, then use `origin` to specify
-       * which hosts will match. Setting `origin` is optional.
+       * By default, `path` will only match URLs under the current host (i.e.
+       * same-origin requests). If you'd like to apply `handler` to cross-origin
+       * requests, then use `origin` to specify which hosts will match. Setting
+       * `origin` is optional.
        *
        * `origin` is a `String`, but it is used internally to construct a
-       * [`RegExp` object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions),
+       * [`RegExp`
+       * object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions),
        * which is used for the matching.
        *
-       * Note that the `origin` value will be matched against the full domain name and the protocol.
-       * If you want to match  'http' and 'https', then use 'https?://' at the start of your string.
+       * Note that the `origin` value will be matched against the full domain name
+       * and the protocol. If you want to match  'http' and 'https', then use
+       * 'https?://' at the start of your string.
        *
        * Some examples:
-       * - `origin="https?://.+\.google\.com"` → a RegExp that matches `http` or `https` requests
-       *   made to any domain that ends in `.google.com`.
-       * - `origin="https://www\.example\.com" → a RegExp that will only match `https` requests to
-       *   one domain, `www.example.com`.
+       * - `origin="https?://.+\.google\.com"` → a RegExp that matches `http` or
+       * `https` requests made to any domain that ends in `.google.com`.
+       * - `origin="https://www\.example\.com" → a RegExp that will only match
+       * `https` requests to one domain, `www.example.com`.
        *
        * @see {@link https://github.com/googlechrome/sw-toolbox#toolboxrouterheadurlpattern-handler-options}
        */
@@ -98,21 +113,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       /**
        * URLs with paths matching `path` will have `handler` applied to them.
        *
-       * By default, `path` will only match same-origin URLs. If you'd like it to match
-       * cross-origin URLs, use `path` in conjunction with `origin`.
+       * By default, `path` will only match same-origin URLs. If you'd like it to
+       * match cross-origin URLs, use `path` in conjunction with `origin`.
        *
        * As explained in the
-       * [`sw-toolbox` docs](https://github.com/googlechrome/sw-toolbox#toolboxrouterheadurlpattern-handler-options),
-       * the URL path matching is done using the [`path-to-regexp`](https://github.com/pillarjs/path-to-regexp)
-       * module, which is the same logic used in [Express-style routing](http://expressjs.com/guide/routing.html).
+       * [`sw-toolbox`
+       * docs](https://github.com/googlechrome/sw-toolbox#toolboxrouterheadurlpattern-handler-options),
+       * the URL path matching is done using the
+       * [`path-to-regexp`](https://github.com/pillarjs/path-to-regexp) module,
+       * which is the same logic used in [Express-style
+       * routing](http://expressjs.com/guide/routing.html).
        *
-       * In practice, you need to always use '/' as the first character of your `path`, and then
-       * can use '(.*)' as a wildcard.
+       * In practice, you need to always use '/' as the first character of your
+       * `path`, and then can use '(.*)' as a wildcard.
        *
        * Some examples:
-       * - `path="/(.*)/customFetch"` → matches any path that ends with '/customFetch'.
-       * - `path="/customFetch(.*)"` → matches any path that starts with '/customFetch', optionally
-       *   followed by other characters.
+       * - `path="/(.*)/customFetch"` → matches any path that ends with
+       * '/customFetch'.
+       * - `path="/customFetch(.*)"` → matches any path that starts with
+       * '/customFetch', optionally followed by other characters.
        *
        * @see {@link https://github.com/pillarjs/path-to-regexp}
        */
@@ -127,8 +146,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (this.path && this.handler) {
           params.route = [this.path, this.handler, this.origin];
         } else {
-          Polymer.Base._warn('The following platinum-sw-fetch element will not have any effect. ' +
-            'Both the "path" and "handler" attributes must be set.', this);
+          Polymer.Base._warn(
+              'The following platinum-sw-fetch element will not have any effect. ' +
+                  'Both the "path" and "handler" attributes must be set.',
+              this);
         }
         resolve(params);
       }.bind(this));

--- a/platinum-sw-import-script.d.ts
+++ b/platinum-sw-import-script.d.ts
@@ -11,23 +11,28 @@
 /// <reference path="../polymer/types/polymer.d.ts" />
 
 /**
- * The `<platinum-sw-import-script>` element is used to import a JavaScript file that is executed
- * each time the service worker starts up.
+ * The `<platinum-sw-import-script>` element is used to import a JavaScript file
+ * that is executed each time the service worker starts up.
  *
- * `<platinum-sw-import-script>` needs to be a child element of `<platinum-sw-register>`.
+ * `<platinum-sw-import-script>` needs to be a child element of
+ * `<platinum-sw-register>`.
  *
- * A common use case is to define a custom request handler for a `fetch` event, but it can be used
- * for any type of code that you want to be executed by the service worker.
+ * A common use case is to define a custom request handler for a `fetch` event,
+ * but it can be used for any type of code that you want to be executed by the
+ * service worker.
  *
  *     <platinum-sw-register auto-register>
- *       <platinum-sw-import-script href="custom-fetch-handler.js"></platinum-sw-import-script>
+ *       <platinum-sw-import-script
+ * href="custom-fetch-handler.js"></platinum-sw-import-script>
  *       <platinum-sw-fetch handler="customFetchHandler"
  *                          path="/(.*)/customFetch"></platinum-sw-fetch>
  *     </platinum-sw-register>
  *
- * You can specify multiple `<platinum-sw-import-script>` elements, each one corresponding to a
- * different JavaScript file. The JavaScript files will be loaded in the order in which the
- * `<platinum-sw-import-script>` elements appear. Under the hood, this results in an
+ * You can specify multiple `<platinum-sw-import-script>` elements, each one
+ * corresponding to a different JavaScript file. The JavaScript files will be
+ * loaded in the order in which the
+ * `<platinum-sw-import-script>` elements appear. Under the hood, this results
+ * in an
  * [`importScripts()`](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/importScripts)
  * call made from the context of the service worker.
  */
@@ -37,8 +42,8 @@ interface PlatinumSwImportScriptElement extends Polymer.Element {
    * The URL of the JavaScript file that you want imported.
    *
    * Relative URLs are assumed to be
-   * relative to the service worker's script location, which will almost always be the same
-   * location as the page which includes this element.
+   * relative to the service worker's script location, which will almost
+   * always be the same location as the page which includes this element.
    */
   href: string|null|undefined;
   _getParameters(): any;

--- a/platinum-sw-import-script.html
+++ b/platinum-sw-import-script.html
@@ -11,23 +11,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
   /**
-   * The `<platinum-sw-import-script>` element is used to import a JavaScript file that is executed
-   * each time the service worker starts up.
+   * The `<platinum-sw-import-script>` element is used to import a JavaScript file
+   * that is executed each time the service worker starts up.
    *
-   * `<platinum-sw-import-script>` needs to be a child element of `<platinum-sw-register>`.
+   * `<platinum-sw-import-script>` needs to be a child element of
+   * `<platinum-sw-register>`.
    *
-   * A common use case is to define a custom request handler for a `fetch` event, but it can be used
-   * for any type of code that you want to be executed by the service worker.
+   * A common use case is to define a custom request handler for a `fetch` event,
+   * but it can be used for any type of code that you want to be executed by the
+   * service worker.
    *
    *     <platinum-sw-register auto-register>
-   *       <platinum-sw-import-script href="custom-fetch-handler.js"></platinum-sw-import-script>
+   *       <platinum-sw-import-script
+   * href="custom-fetch-handler.js"></platinum-sw-import-script>
    *       <platinum-sw-fetch handler="customFetchHandler"
    *                          path="/(.*)/customFetch"></platinum-sw-fetch>
    *     </platinum-sw-register>
    *
-   * You can specify multiple `<platinum-sw-import-script>` elements, each one corresponding to a
-   * different JavaScript file. The JavaScript files will be loaded in the order in which the
-   * `<platinum-sw-import-script>` elements appear. Under the hood, this results in an
+   * You can specify multiple `<platinum-sw-import-script>` elements, each one
+   * corresponding to a different JavaScript file. The JavaScript files will be
+   * loaded in the order in which the
+   * `<platinum-sw-import-script>` elements appear. Under the hood, this results
+   * in an
    * [`importScripts()`](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/importScripts)
    * call made from the context of the service worker.
    */
@@ -39,8 +44,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * The URL of the JavaScript file that you want imported.
        *
        * Relative URLs are assumed to be
-       * relative to the service worker's script location, which will almost always be the same
-       * location as the page which includes this element.
+       * relative to the service worker's script location, which will almost
+       * always be the same location as the page which includes this element.
        */
       href: String
     },
@@ -51,8 +56,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (this.href) {
           params.importscript = this.href;
         } else {
-          Polymer.Base._warn('The following platinum-sw-import-script element will not have any effect.' +
-            ' The "href" attribute must be set.', this);
+          Polymer.Base._warn(
+              'The following platinum-sw-import-script element will not have any effect.' +
+                  ' The "href" attribute must be set.',
+              this);
         }
         resolve(params);
       }.bind(this));

--- a/platinum-sw-offline-analytics.d.ts
+++ b/platinum-sw-offline-analytics.d.ts
@@ -11,26 +11,30 @@
 /// <reference path="../polymer/types/polymer.d.ts" />
 
 /**
- * The `<platinum-sw-offline-analytics>` element registers a service worker handler to
- * intercept requests for Google Analytics pings.
+ * The `<platinum-sw-offline-analytics>` element registers a service worker
+ * handler to intercept requests for Google Analytics pings.
  *
- * If the HTTP GET for the ping is successful (because the browser is online), then everything
- * proceeds as it normally would. If the HTTP GET fails, the ping request is saved to IndexedDB, and each time the service worker
- * script starts up it will attempt to "replay" those saved ping requests, giving up after one day
- * has passed.
+ * If the HTTP GET for the ping is successful (because the browser is online),
+ * then everything proceeds as it normally would. If the HTTP GET fails, the
+ * ping request is saved to IndexedDB, and each time the service worker script
+ * starts up it will attempt to "replay" those saved ping requests, giving up
+ * after one day has passed.
  *
- * The [`qt`](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#qt)
- * URL parameter is automatically added to the replayed HTTP GET and set to the number of
- * milliseconds that has passed since the initial ping request was attempted, to ensure that the
- * original time attribution is correct.
+ * The
+ * [`qt`](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#qt)
+ * URL parameter is automatically added to the replayed HTTP GET and set to the
+ * number of milliseconds that has passed since the initial ping request was
+ * attempted, to ensure that the original time attribution is correct.
  *
- * `<platinum-sw-offline-analytics>` does not take care of setting up Google Analytics on your
- * page, and assumes that you have [properly configured](https://support.google.com/analytics/answer/1008080)
- * the Google Analytics tracking code registered elsewhere on your page.
+ * `<platinum-sw-offline-analytics>` does not take care of setting up Google
+ * Analytics on your page, and assumes that you have [properly
+ * configured](https://support.google.com/analytics/answer/1008080) the Google
+ * Analytics tracking code registered elsewhere on your page.
  *
- * Since `<platinum-sw-offline-analytics>` is only useful if the page that is being tracked with
- * Google Analytics works offline, it's best used in conjunction with the `<platinum-sw-cache>`
- * element, which takes care of caching your site's resources and serving them while offline.
+ * Since `<platinum-sw-offline-analytics>` is only useful if the page that is
+ * being tracked with Google Analytics works offline, it's best used in
+ * conjunction with the `<platinum-sw-cache>` element, which takes care of
+ * caching your site's resources and serving them while offline.
  *
  * A basic configuration is
  *

--- a/platinum-sw-offline-analytics.html
+++ b/platinum-sw-offline-analytics.html
@@ -11,26 +11,30 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
   /**
-   * The `<platinum-sw-offline-analytics>` element registers a service worker handler to
-   * intercept requests for Google Analytics pings.
+   * The `<platinum-sw-offline-analytics>` element registers a service worker
+   * handler to intercept requests for Google Analytics pings.
    *
-   * If the HTTP GET for the ping is successful (because the browser is online), then everything
-   * proceeds as it normally would. If the HTTP GET fails, the ping request is saved to IndexedDB, and each time the service worker
-   * script starts up it will attempt to "replay" those saved ping requests, giving up after one day
-   * has passed.
+   * If the HTTP GET for the ping is successful (because the browser is online),
+   * then everything proceeds as it normally would. If the HTTP GET fails, the
+   * ping request is saved to IndexedDB, and each time the service worker script
+   * starts up it will attempt to "replay" those saved ping requests, giving up
+   * after one day has passed.
    *
-   * The [`qt`](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#qt)
-   * URL parameter is automatically added to the replayed HTTP GET and set to the number of
-   * milliseconds that has passed since the initial ping request was attempted, to ensure that the
-   * original time attribution is correct.
+   * The
+   * [`qt`](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#qt)
+   * URL parameter is automatically added to the replayed HTTP GET and set to the
+   * number of milliseconds that has passed since the initial ping request was
+   * attempted, to ensure that the original time attribution is correct.
    *
-   * `<platinum-sw-offline-analytics>` does not take care of setting up Google Analytics on your
-   * page, and assumes that you have [properly configured](https://support.google.com/analytics/answer/1008080)
-   * the Google Analytics tracking code registered elsewhere on your page.
+   * `<platinum-sw-offline-analytics>` does not take care of setting up Google
+   * Analytics on your page, and assumes that you have [properly
+   * configured](https://support.google.com/analytics/answer/1008080) the Google
+   * Analytics tracking code registered elsewhere on your page.
    *
-   * Since `<platinum-sw-offline-analytics>` is only useful if the page that is being tracked with
-   * Google Analytics works offline, it's best used in conjunction with the `<platinum-sw-cache>`
-   * element, which takes care of caching your site's resources and serving them while offline.
+   * Since `<platinum-sw-offline-analytics>` is only useful if the page that is
+   * being tracked with Google Analytics works offline, it's best used in
+   * conjunction with the `<platinum-sw-cache>` element, which takes care of
+   * caching your site's resources and serving them while offline.
    *
    * A basic configuration is
    *

--- a/platinum-sw-register.d.ts
+++ b/platinum-sw-register.d.ts
@@ -12,10 +12,12 @@
 
 /**
  * The `<platinum-sw-register>` element handles
- * [service worker](http://www.html5rocks.com/en/tutorials/service-worker/introduction/)
- * registration, reflects the overall service worker state, and coordinates the configuration
- * provided by other Service Worker Elements.
- * `<platinum-sw-register>` is used as a parent element for child elements in the
+ * [service
+ * worker](http://www.html5rocks.com/en/tutorials/service-worker/introduction/)
+ * registration, reflects the overall service worker state, and coordinates the
+ * configuration provided by other Service Worker Elements.
+ * `<platinum-sw-register>` is used as a parent element for child elements in
+ * the
  * `<platinum-sw-*>` group.
  *
  *     <platinum-sw-register skip-waiting
@@ -25,93 +27,106 @@
  *                           on-service-worker-error="handleSWError"
  *                           on-service-worker-updated="handleSWUpdated"
  *                           on-service-worker-installed="handleSWInstalled">
- *       ...one or more <platinum-sw-*> children which share the service worker registration...
+ *       ...one or more <platinum-sw-*> children which share the service worker
+ * registration...
  *     </platinum-sw-register>
  *
- * Please see https://github.com/PolymerElements/platinum-sw#top-level-sw-importjs for a
- * *crucial* prerequisite file you must create before `<platinum-sw-register>` can be used!
+ * Please see
+ * https://github.com/PolymerElements/platinum-sw#top-level-sw-importjs for a
+ * *crucial* prerequisite file you must create before `<platinum-sw-register>`
+ * can be used!
  */
 interface PlatinumSwRegisterElement extends Polymer.Element {
 
   /**
-   * Whether this element should automatically register the corresponding service worker as
-   * soon as its added to a page.
+   * Whether this element should automatically register the corresponding
+   * service worker as soon as its added to a page.
    *
-   * If set to `false`, then the service worker won't be automatically registered, and you
-   * must call this element's `register()` method if you want service worker functionality.
-   * This is useful if, for example, the service worker needs to be configured using
-   * information that isn't immediately available at the time the page loads.
+   * If set to `false`, then the service worker won't be automatically
+   * registered, and you must call this element's `register()` method if you
+   * want service worker functionality. This is useful if, for example, the
+   * service worker needs to be configured using information that isn't
+   * immediately available at the time the page loads.
    *
-   * If set to `true`, the service worker will be automatically registered without having to
-   * call any methods.
+   * If set to `true`, the service worker will be automatically registered
+   * without having to call any methods.
    */
   autoRegister: boolean|null|undefined;
 
   /**
-   * The URI used as a base when constructing relative paths to service worker helper libraries
-   * that need to be loaded.
+   * The URI used as a base when constructing relative paths to service worker
+   * helper libraries that need to be loaded.
    *
-   * This can normally be kept set to the default, which will use the directory containing this
-   * element as the base. However, if you [Vulcanize](https://github.com/polymer/vulcanize) your
-   * elements, then the default base might not be appropriate anymore. This will allow you to
+   * This can normally be kept set to the default, which will use the
+   * directory containing this element as the base. However, if you
+   * [Vulcanize](https://github.com/polymer/vulcanize) your elements, then the
+   * default base might not be appropriate anymore. This will allow you to
    * override it.
    *
-   * See https://github.com/PolymerElements/platinum-sw#relative-paths--vulcanization for more
-   * information.
+   * See
+   * https://github.com/PolymerElements/platinum-sw#relative-paths--vulcanization
+   * for more information.
    */
   baseUri: string|null|undefined;
 
   /**
-   * Whether the activated service worker should [take immediate control](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#clients-claim-method)
+   * Whether the activated service worker should [take immediate
+   * control](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#clients-claim-method)
    * of any pages under its scope.
    *
-   * If this is `false`, the service worker won't have any effect until the next time the page
-   * is visited/reloaded.
-   * If this is `true`, it will take control and start handling events for the current page
-   * (and any pages under the same scope open in other tabs/windows) as soon it's active.
+   * If this is `false`, the service worker won't have any effect until the
+   * next time the page is visited/reloaded. If this is `true`, it will take
+   * control and start handling events for the current page (and any pages
+   * under the same scope open in other tabs/windows) as soon it's active.
    */
   clientsClaim: boolean|null|undefined;
 
   /**
-   * The service worker script that is [registered](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#navigator-service-worker-register).
-   * The script *should* be located at the top level of your site, to ensure that it is able
-   * to control all the pages on your site.
+   * The service worker script that is
+   * [registered](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#navigator-service-worker-register).
+   * The script *should* be located at the top level of your site, to ensure
+   * that it is able to control all the pages on your site.
    *
-   * It's *strongly* recommended that you create a top-level file named `sw-import.js`
-   * containing only:
+   * It's *strongly* recommended that you create a top-level file named
+   * `sw-import.js` containing only:
    *
    * `importScripts('bower_components/platinum-sw/service-worker.js');`
    *
-   * (adjust to match the path where your `platinum-sw` element directory can be found).
+   * (adjust to match the path where your `platinum-sw` element directory can
+   * be found).
    *
-   * This will ensure that your service worker script contains everything needed to play
-   * nicely with the Service Worker Elements group.
+   * This will ensure that your service worker script contains everything
+   * needed to play nicely with the Service Worker Elements group.
    */
   href: string|null|undefined;
 
   /**
-   * Whether the page should be automatically reloaded (via `window.location.reload()`) when
-   * the service worker is successfully installed.
+   * Whether the page should be automatically reloaded (via
+   * `window.location.reload()`) when the service worker is successfully
+   * installed.
    *
-   * While it's perfectly valid to continue using a page with a freshly installed service
-   * worker, it's a common pattern to want to reload it immediately following the install.
-   * This ensures that, for example, if you're using a `<platinum-sw-cache>` with an on the
-   * fly caching strategy, it will get a chance to intercept all the requests needed to render
-   * your page and store them in the cache.
+   * While it's perfectly valid to continue using a page with a freshly
+   * installed service worker, it's a common pattern to want to reload it
+   * immediately following the install. This ensures that, for example, if
+   * you're using a `<platinum-sw-cache>` with an on the fly caching strategy,
+   * it will get a chance to intercept all the requests needed to render your
+   * page and store them in the cache.
    *
-   * If you don't immediately reload your page, then any resources that were loaded before the
-   * service worker was installed (e.g. this `platinum-sw-register.html` file) won't be present
-   * in the cache until the next time the page is loaded.
+   * If you don't immediately reload your page, then any resources that were
+   * loaded before the service worker was installed (e.g. this
+   * `platinum-sw-register.html` file) won't be present in the cache until the
+   * next time the page is loaded.
    *
-   * Note that this reload will only happen when a service worker is installed for the first
-   * time. If the service worker is subsequently updated, it won't trigger another reload.
+   * Note that this reload will only happen when a service worker is installed
+   * for the first time. If the service worker is subsequently updated, it
+   * won't trigger another reload.
    */
   reloadOnInstall: boolean|null|undefined;
 
   /**
-   * By default, the service worker will use a scope that applies to all pages at the same
-   * directory level or lower. This is almost certainly what you want, as illustrated by the
-   * following hypothetical serving setup:
+   * By default, the service worker will use a scope that applies to all pages
+   * at the same directory level or lower. This is almost certainly what you
+   * want, as illustrated by the following hypothetical serving setup:
    *
    * ```
    * /root/
@@ -123,30 +138,37 @@ interface PlatinumSwRegisterElement extends Polymer.Element {
    *     index.html
    * ```
    *
-   * So by default, registering `/root/service-worker.js` will cause the service worker's scope
-   * to cover `/root/index.html`, `/root/subdir1/index.html`, and `/root/subdir2/index.html`.
+   * So by default, registering `/root/service-worker.js` will cause the
+   * service worker's scope to cover `/root/index.html`,
+   * `/root/subdir1/index.html`, and `/root/subdir2/index.html`.
    *
-   * If, for some reason, you need to register `/root/service-worker.js` from within
-   * `/root/subdir1/index.html`, *and* you want that registration to only cover
-   * `/root/subdir1/**`, you can override this `scope` property and set it to `'./'`.
+   * If, for some reason, you need to register `/root/service-worker.js` from
+   * within
+   * `/root/subdir1/index.html`, *and* you want that registration to only
+   * cover
+   * `/root/subdir1/**`, you can override this `scope` property and set it to
+   * `'./'`.
    *
-   * There is more context about default scopes and how scope overrides work in
-   * [this Stack Overflow](http://stackoverflow.com/a/33881341/385997) response.
+   * There is more context about default scopes and how scope overrides work
+   * in [this Stack Overflow](http://stackoverflow.com/a/33881341/385997)
+   * response.
    */
   scope: string|null|undefined;
 
   /**
-   * Whether an updated service worker should [bypass the `waiting` state](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-global-scope-skipwaiting)
+   * Whether an updated service worker should [bypass the `waiting`
+   * state](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-global-scope-skipwaiting)
    * and immediately become `active`.
    *
    * Normally, during an update, the new service worker stays in the
-   * `waiting` state until the current page and any other tabs/windows that are using the old
-   * service worker are unloaded.
+   * `waiting` state until the current page and any other tabs/windows that
+   * are using the old service worker are unloaded.
    *
-   * If this is `false`, an updated service worker won't be activated until all instances of
-   * the old server worker have been unloaded.
+   * If this is `false`, an updated service worker won't be activated until
+   * all instances of the old server worker have been unloaded.
    *
-   * If this is `true`, an updated service worker will become `active` immediately.
+   * If this is `true`, an updated service worker will become `active`
+   * immediately.
    */
   skipWaiting: boolean|null|undefined;
 
@@ -162,18 +184,18 @@ interface PlatinumSwRegisterElement extends Polymer.Element {
   readonly state: string|null|undefined;
 
   /**
-   *  kept in sync with the element's release number.
+   *  release number.
    */
   _version: string;
 
   /**
-   * Registers the service worker based on the configuration options in this element and any
-   * child elements.
+   * Registers the service worker based on the configuration options in this
+   * element and any child elements.
    *
-   * If you set the `autoRegister` property to `true`, then this method is called automatically
-   * at page load.
-   * It can be useful to set `autoRegister` to `false` and then explicitly call this method if
-   * there are options that are only configured after the page is loaded.
+   * If you set the `autoRegister` property to `true`, then this method is
+   * called automatically at page load. It can be useful to set `autoRegister`
+   * to `false` and then explicitly call this method if there are options that
+   * are only configured after the page is loaded.
    */
   register(): void;
   _constructServiceWorkerUrl(): any;

--- a/platinum-sw-register.html
+++ b/platinum-sw-register.html
@@ -12,10 +12,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script>
   /**
    * The `<platinum-sw-register>` element handles
-   * [service worker](http://www.html5rocks.com/en/tutorials/service-worker/introduction/)
-   * registration, reflects the overall service worker state, and coordinates the configuration
-   * provided by other Service Worker Elements.
-   * `<platinum-sw-register>` is used as a parent element for child elements in the
+   * [service
+   * worker](http://www.html5rocks.com/en/tutorials/service-worker/introduction/)
+   * registration, reflects the overall service worker state, and coordinates the
+   * configuration provided by other Service Worker Elements.
+   * `<platinum-sw-register>` is used as a parent element for child elements in
+   * the
    * `<platinum-sw-*>` group.
    *
    *     <platinum-sw-register skip-waiting
@@ -25,28 +27,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    *                           on-service-worker-error="handleSWError"
    *                           on-service-worker-updated="handleSWUpdated"
    *                           on-service-worker-installed="handleSWInstalled">
-   *       ...one or more <platinum-sw-*> children which share the service worker registration...
+   *       ...one or more <platinum-sw-*> children which share the service worker
+   * registration...
    *     </platinum-sw-register>
    *
-   * Please see https://github.com/PolymerElements/platinum-sw#top-level-sw-importjs for a
-   * *crucial* prerequisite file you must create before `<platinum-sw-register>` can be used!
+   * Please see
+   * https://github.com/PolymerElements/platinum-sw#top-level-sw-importjs for a
+   * *crucial* prerequisite file you must create before `<platinum-sw-register>`
+   * can be used!
    *
    * @demo demo/index.html An offline-capable eReader demo.
    */
   Polymer({
     is: 'platinum-sw-register',
 
-    // Used as an "emergency" switch if we make breaking changes in the way <platinum-sw-register>
-    // talks to service-worker.js. Otherwise, it shouldn't need to change, and isn't meant to be
-    // kept in sync with the element's release number.
+    // Used as an "emergency" switch if we make breaking changes in the way
+    // <platinum-sw-register> talks to service-worker.js. Otherwise, it shouldn't
+    // need to change, and isn't meant to be kept in sync with the element's
+    // release number.
     _version: '1.0',
 
     /**
      * Fired when the initial service worker installation completes successfully.
-     * The service worker will normally only be installed once, the first time a page with a
-     * `<platinum-sw-register>` element is visited in a given browser. If the same page is visited
-     * again, the existing service worker will be reused, and there won't be another
-     * `service-worker-installed` fired.
+     * The service worker will normally only be installed once, the first time a
+     * page with a
+     * `<platinum-sw-register>` element is visited in a given browser. If the same
+     * page is visited again, the existing service worker will be reused, and
+     * there won't be another `service-worker-installed` fired.
      *
      * @event service-worker-installed
      * @param {String} A message indicating that the installation succeeded.
@@ -54,16 +61,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     /**
      * Fired when the service worker update flow completes successfully.
-     * If you make changes to your `<platinum-sw-register>` configuration (i.e. by adding in new
-     * `<platinum-sw-*>` child elements, or changing their attributes), users who had the old
-     * service worker installed will get the update installed when they see the modified elements.
+     * If you make changes to your `<platinum-sw-register>` configuration (i.e. by
+     * adding in new
+     * `<platinum-sw-*>` child elements, or changing their attributes), users who
+     * had the old service worker installed will get the update installed when
+     * they see the modified elements.
      *
      * @event service-worker-updated
      * @param {String} A message indicating that the update succeeded.
      */
 
     /**
-     * Fired when an error prevents the service worker installation from completing.
+     * Fired when an error prevents the service worker installation from
+     * completing.
      *
      * @event service-worker-error
      * @param {String} A message indicating what went wrong.
@@ -71,110 +81,112 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     properties: {
       /**
-       * Whether this element should automatically register the corresponding service worker as
-       * soon as its added to a page.
+       * Whether this element should automatically register the corresponding
+       * service worker as soon as its added to a page.
        *
-       * If set to `false`, then the service worker won't be automatically registered, and you
-       * must call this element's `register()` method if you want service worker functionality.
-       * This is useful if, for example, the service worker needs to be configured using
-       * information that isn't immediately available at the time the page loads.
+       * If set to `false`, then the service worker won't be automatically
+       * registered, and you must call this element's `register()` method if you
+       * want service worker functionality. This is useful if, for example, the
+       * service worker needs to be configured using information that isn't
+       * immediately available at the time the page loads.
        *
-       * If set to `true`, the service worker will be automatically registered without having to
-       * call any methods.
+       * If set to `true`, the service worker will be automatically registered
+       * without having to call any methods.
        */
-      autoRegister: {
-        type: Boolean,
-        value: false
-      },
+      autoRegister: {type: Boolean, value: false},
 
       /**
-       * The URI used as a base when constructing relative paths to service worker helper libraries
-       * that need to be loaded.
+       * The URI used as a base when constructing relative paths to service worker
+       * helper libraries that need to be loaded.
        *
-       * This can normally be kept set to the default, which will use the directory containing this
-       * element as the base. However, if you [Vulcanize](https://github.com/polymer/vulcanize) your
-       * elements, then the default base might not be appropriate anymore. This will allow you to
+       * This can normally be kept set to the default, which will use the
+       * directory containing this element as the base. However, if you
+       * [Vulcanize](https://github.com/polymer/vulcanize) your elements, then the
+       * default base might not be appropriate anymore. This will allow you to
        * override it.
        *
-       * See https://github.com/PolymerElements/platinum-sw#relative-paths--vulcanization for more
-       * information.
+       * See
+       * https://github.com/PolymerElements/platinum-sw#relative-paths--vulcanization
+       * for more information.
        */
       baseUri: {
         type: String,
-        // Grab the URI of this file to use as a base when resolving relative paths.
-        // See https://github.com/webcomponents/webcomponentsjs/blob/88240ba9ef4cebb1579e07f7888c7b58ec017a39/src/HTMLImports/base.js#L31
-        // for background on document._currentScript. We want to support document.currentScript
-        // as well, on the off chance that the polyfills aren't loaded.
-        // Fallback to './' as a default, though current browsers that don't support
-        // document.currentScript also don't support service workers.
-        value: document._currentScript ? document._currentScript.baseURI :
-          (HTMLImports.importForElement ? HTMLImports.importForElement(document.currentScript).baseURI :
-          (document.currentScript ? document.currentScript.baseURI : './'))
+        // Grab the URI of this file to use as a base when resolving relative
+        // paths. See
+        // https://github.com/webcomponents/webcomponentsjs/blob/88240ba9ef4cebb1579e07f7888c7b58ec017a39/src/HTMLImports/base.js#L31
+        // for background on document._currentScript. We want to support
+        // document.currentScript as well, on the off chance that the polyfills
+        // aren't loaded. Fallback to './' as a default, though current browsers
+        // that don't support document.currentScript also don't support service
+        // workers.
+        value: document._currentScript ?
+            document._currentScript.baseURI :
+            (HTMLImports.importForElement ?
+                 HTMLImports.importForElement(document.currentScript).baseURI :
+                 (document.currentScript ? document.currentScript.baseURI : './'))
       },
 
       /**
-       * Whether the activated service worker should [take immediate control](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#clients-claim-method)
+       * Whether the activated service worker should [take immediate
+       * control](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#clients-claim-method)
        * of any pages under its scope.
        *
-       * If this is `false`, the service worker won't have any effect until the next time the page
-       * is visited/reloaded.
-       * If this is `true`, it will take control and start handling events for the current page
-       * (and any pages under the same scope open in other tabs/windows) as soon it's active.
+       * If this is `false`, the service worker won't have any effect until the
+       * next time the page is visited/reloaded. If this is `true`, it will take
+       * control and start handling events for the current page (and any pages
+       * under the same scope open in other tabs/windows) as soon it's active.
        * @see {@link https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#clients-claim-method}
        */
-      clientsClaim: {
-        type: Boolean,
-        value: false
-      },
+      clientsClaim: {type: Boolean, value: false},
 
       /**
-       * The service worker script that is [registered](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#navigator-service-worker-register).
-       * The script *should* be located at the top level of your site, to ensure that it is able
-       * to control all the pages on your site.
+       * The service worker script that is
+       * [registered](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#navigator-service-worker-register).
+       * The script *should* be located at the top level of your site, to ensure
+       * that it is able to control all the pages on your site.
        *
-       * It's *strongly* recommended that you create a top-level file named `sw-import.js`
-       * containing only:
+       * It's *strongly* recommended that you create a top-level file named
+       * `sw-import.js` containing only:
        *
        * `importScripts('bower_components/platinum-sw/service-worker.js');`
        *
-       * (adjust to match the path where your `platinum-sw` element directory can be found).
+       * (adjust to match the path where your `platinum-sw` element directory can
+       * be found).
        *
-       * This will ensure that your service worker script contains everything needed to play
-       * nicely with the Service Worker Elements group.
+       * This will ensure that your service worker script contains everything
+       * needed to play nicely with the Service Worker Elements group.
        *
        * @see {@link https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#navigator-service-worker-register}
        */
-      href: {
-        type: String,
-        value: 'sw-import.js'
-      },
+      href: {type: String, value: 'sw-import.js'},
 
       /**
-       * Whether the page should be automatically reloaded (via `window.location.reload()`) when
-       * the service worker is successfully installed.
+       * Whether the page should be automatically reloaded (via
+       * `window.location.reload()`) when the service worker is successfully
+       * installed.
        *
-       * While it's perfectly valid to continue using a page with a freshly installed service
-       * worker, it's a common pattern to want to reload it immediately following the install.
-       * This ensures that, for example, if you're using a `<platinum-sw-cache>` with an on the
-       * fly caching strategy, it will get a chance to intercept all the requests needed to render
-       * your page and store them in the cache.
+       * While it's perfectly valid to continue using a page with a freshly
+       * installed service worker, it's a common pattern to want to reload it
+       * immediately following the install. This ensures that, for example, if
+       * you're using a `<platinum-sw-cache>` with an on the fly caching strategy,
+       * it will get a chance to intercept all the requests needed to render your
+       * page and store them in the cache.
        *
-       * If you don't immediately reload your page, then any resources that were loaded before the
-       * service worker was installed (e.g. this `platinum-sw-register.html` file) won't be present
-       * in the cache until the next time the page is loaded.
+       * If you don't immediately reload your page, then any resources that were
+       * loaded before the service worker was installed (e.g. this
+       * `platinum-sw-register.html` file) won't be present in the cache until the
+       * next time the page is loaded.
        *
-       * Note that this reload will only happen when a service worker is installed for the first
-       * time. If the service worker is subsequently updated, it won't trigger another reload.
+       * Note that this reload will only happen when a service worker is installed
+       * for the first time. If the service worker is subsequently updated, it
+       * won't trigger another reload.
        */
-      reloadOnInstall: {
-        type: Boolean,
-        value: false
-      },
+      reloadOnInstall: {type: Boolean, value: false},
 
       /**
-       * By default, the service worker will use a scope that applies to all pages at the same
-       * directory level or lower. This is almost certainly what you want, as illustrated by the
-       * following hypothetical serving setup:
+       * By default, the service worker will use a scope that applies to all pages
+       * at the same directory level or lower. This is almost certainly what you
+       * want, as illustrated by the following hypothetical serving setup:
        *
        * ```
        * /root/
@@ -186,41 +198,42 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *     index.html
        * ```
        *
-       * So by default, registering `/root/service-worker.js` will cause the service worker's scope
-       * to cover `/root/index.html`, `/root/subdir1/index.html`, and `/root/subdir2/index.html`.
+       * So by default, registering `/root/service-worker.js` will cause the
+       * service worker's scope to cover `/root/index.html`,
+       * `/root/subdir1/index.html`, and `/root/subdir2/index.html`.
        *
-       * If, for some reason, you need to register `/root/service-worker.js` from within
-       * `/root/subdir1/index.html`, *and* you want that registration to only cover
-       * `/root/subdir1/**`, you can override this `scope` property and set it to `'./'`.
+       * If, for some reason, you need to register `/root/service-worker.js` from
+       * within
+       * `/root/subdir1/index.html`, *and* you want that registration to only
+       * cover
+       * `/root/subdir1/**`, you can override this `scope` property and set it to
+       * `'./'`.
        *
-       * There is more context about default scopes and how scope overrides work in
-       * [this Stack Overflow](http://stackoverflow.com/a/33881341/385997) response.
+       * There is more context about default scopes and how scope overrides work
+       * in [this Stack Overflow](http://stackoverflow.com/a/33881341/385997)
+       * response.
        *
        * @see {@link https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#navigator-service-worker-register}
        */
-      scope: {
-        type: String,
-        value: null
-      },
+      scope: {type: String, value: null},
 
       /**
-       * Whether an updated service worker should [bypass the `waiting` state](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-global-scope-skipwaiting)
+       * Whether an updated service worker should [bypass the `waiting`
+       * state](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-global-scope-skipwaiting)
        * and immediately become `active`.
        *
        * Normally, during an update, the new service worker stays in the
-       * `waiting` state until the current page and any other tabs/windows that are using the old
-       * service worker are unloaded.
+       * `waiting` state until the current page and any other tabs/windows that
+       * are using the old service worker are unloaded.
        *
-       * If this is `false`, an updated service worker won't be activated until all instances of
-       * the old server worker have been unloaded.
+       * If this is `false`, an updated service worker won't be activated until
+       * all instances of the old server worker have been unloaded.
        *
-       * If this is `true`, an updated service worker will become `active` immediately.
+       * If this is `true`, an updated service worker will become `active`
+       * immediately.
        * @see {@link https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-global-scope-skipwaiting}
        */
-      skipWaiting: {
-        type: Boolean,
-        value: false
-      },
+      skipWaiting: {type: Boolean, value: false},
 
       /**
        * The current state of the service worker registered by this element.
@@ -231,21 +244,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * - 'error'
        * - 'unsupported'
        */
-      state: {
-        notify: true,
-        readOnly: true,
-        type: String
-      }
+      state: {notify: true, readOnly: true, type: String}
     },
 
     /**
-     * Registers the service worker based on the configuration options in this element and any
-     * child elements.
+     * Registers the service worker based on the configuration options in this
+     * element and any child elements.
      *
-     * If you set the `autoRegister` property to `true`, then this method is called automatically
-     * at page load.
-     * It can be useful to set `autoRegister` to `false` and then explicitly call this method if
-     * there are options that are only configured after the page is loaded.
+     * If you set the `autoRegister` property to `true`, then this method is
+     * called automatically at page load. It can be useful to set `autoRegister`
+     * to `false` and then explicitly call this method if there are options that
+     * are only configured after the page is loaded.
      */
     register: function() {
       if ('serviceWorker' in navigator) {
@@ -266,51 +275,53 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       }
 
-      return Promise.all(paramsPromises).then(function(paramsResolutions) {
-        var params = {
-          baseURI: baseUri,
-          version: this._version
-        };
+      return Promise.all(paramsPromises)
+          .then(function(paramsResolutions) {
+            var params = {baseURI: baseUri, version: this._version};
 
-        paramsResolutions.forEach(function(childParams) {
-          Object.keys(childParams).forEach(function(key) {
-            if (Array.isArray(params[key])) {
-              params[key] = params[key].concat(childParams[key]);
-            } else {
-              params[key] = [].concat(childParams[key]);
+            paramsResolutions.forEach(function(childParams) {
+              Object.keys(childParams).forEach(function(key) {
+                if (Array.isArray(params[key])) {
+                  params[key] = params[key].concat(childParams[key]);
+                } else {
+                  params[key] = [].concat(childParams[key]);
+                }
+              });
+            });
+
+            return params;
+          }.bind(this))
+          .then(function(params) {
+            if (params.importscriptLate) {
+              if (params.importscript) {
+                params.importscript =
+                    params.importscript.concat(params.importscriptLate);
+              } else {
+                params.importscript = params.importscriptLate;
+              }
             }
-          });
-        });
 
-        return params;
-      }.bind(this)).then(function(params) {
-        if (params.importscriptLate) {
-          if (params.importscript) {
-            params.importscript = params.importscript.concat(params.importscriptLate);
-          } else {
-            params.importscript = params.importscriptLate;
-          }
-        }
+            if (params.importscript) {
+              params.importscript = this._unique(params.importscript);
+            }
 
-        if (params.importscript) {
-          params.importscript = this._unique(params.importscript);
-        }
+            // We've already concatenated importscriptLate, so don't include it in
+            // the serialized URL.
+            delete params.importscriptLate;
 
-        // We've already concatenated importscriptLate, so don't include it in the serialized URL.
-        delete params.importscriptLate;
+            params.clientsClaim = this.clientsClaim;
+            params.skipWaiting = this.skipWaiting;
 
-        params.clientsClaim = this.clientsClaim;
-        params.skipWaiting = this.skipWaiting;
+            var serviceWorkerUrl = new URL(this.href, window.location);
+            // It's very important to ensure that the serialization is stable.
+            // Serializing the same settings should always produce the same URL.
+            // Serializing different settings should always produce a different
+            // URL. This ensures that the service worker upgrade flow is triggered
+            // when settings change.
+            serviceWorkerUrl.search = this._serializeUrlParams(params);
 
-        var serviceWorkerUrl = new URL(this.href, window.location);
-        // It's very important to ensure that the serialization is stable.
-        // Serializing the same settings should always produce the same URL.
-        // Serializing different settings should always produce a different URL.
-        // This ensures that the service worker upgrade flow is triggered when settings change.
-        serviceWorkerUrl.search = this._serializeUrlParams(params);
-
-        return serviceWorkerUrl;
-      }.bind(this));
+            return serviceWorkerUrl;
+          }.bind(this));
     },
 
     _unique: function(arr) {
@@ -320,57 +331,71 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _serializeUrlParams: function(params) {
-      return Object.keys(params).sort().map(function(key) {
-        // encodeURIComponent(['a', 'b']) => 'a%2Cb',
-        // so this will still work when the values are Arrays.
-        // TODO: It won't work if the values in the Arrays have ',' characters in them.
-        return encodeURIComponent(key) + "=" + encodeURIComponent(params[key]);
-      }).join('&');
+      return Object.keys(params)
+          .sort()
+          .map(function(key) {
+            // encodeURIComponent(['a', 'b']) => 'a%2Cb',
+            // so this will still work when the values are Arrays.
+            // TODO: It won't work if the values in the Arrays have ',' characters
+            // in them.
+            return encodeURIComponent(key) + '=' +
+                encodeURIComponent(params[key]);
+          })
+          .join('&');
     },
 
     _registerServiceWorker: function(serviceWorkerUrl) {
       var options = this.scope ? {scope: this.scope} : null;
-      navigator.serviceWorker.register(serviceWorkerUrl, options).then(function(registration) {
-        if (registration.active) {
-          this._setState('installed');
-        }
-
-        registration.onupdatefound = function() {
-          var installingWorker = registration.installing;
-          installingWorker.onstatechange = function() {
-            switch (installingWorker.state) {
-              case 'installed':
-                if (navigator.serviceWorker.controller) {
-                  this._setState('updated');
-                  this.fire('service-worker-updated',
-                    'A new service worker was installed, replacing the old service worker.');
-                } else {
-                  if (this.reloadOnInstall) {
-                    window.location.reload();
-                  } else {
-                    this._setState('installed');
-                    this.fire('service-worker-installed', 'A new service worker was installed.');
-                  }
-                }
-              break;
-
-              case 'redundant':
-                this._setState('error');
-                this.fire('service-worker-error', 'The installing service worker became redundant.');
-              break;
+      navigator.serviceWorker.register(serviceWorkerUrl, options)
+          .then(function(registration) {
+            if (registration.active) {
+              this._setState('installed');
             }
-          }.bind(this);
-        }.bind(this);
-      }.bind(this)).catch(function(error) {
-        this._setState('error');
-        this.fire('service-worker-error', error.toString());
-        if (error.name === 'NetworkError') {
-          var location = serviceWorkerUrl.origin + serviceWorkerUrl.pathname;
-          Polymer.Base._error('A valid service worker script was not found at ' + location + '\n' +
-            'To learn how to fix this, please see\n' +
-            'https://github.com/PolymerElements/platinum-sw#top-level-sw-importjs');
-        }
-      }.bind(this));
+
+            registration.onupdatefound = function() {
+              var installingWorker = registration.installing;
+              installingWorker.onstatechange = function() {
+                switch (installingWorker.state) {
+                  case 'installed':
+                    if (navigator.serviceWorker.controller) {
+                      this._setState('updated');
+                      this.fire(
+                          'service-worker-updated',
+                          'A new service worker was installed, replacing the old service worker.');
+                    } else {
+                      if (this.reloadOnInstall) {
+                        window.location.reload();
+                      } else {
+                        this._setState('installed');
+                        this.fire(
+                            'service-worker-installed',
+                            'A new service worker was installed.');
+                      }
+                    }
+                    break;
+
+                  case 'redundant':
+                    this._setState('error');
+                    this.fire(
+                        'service-worker-error',
+                        'The installing service worker became redundant.');
+                    break;
+                }
+              }.bind(this);
+            }.bind(this);
+          }.bind(this))
+          .catch(function(error) {
+            this._setState('error');
+            this.fire('service-worker-error', error.toString());
+            if (error.name === 'NetworkError') {
+              var location = serviceWorkerUrl.origin + serviceWorkerUrl.pathname;
+              Polymer.Base._error(
+                  'A valid service worker script was not found at ' + location +
+                  '\n' +
+                  'To learn how to fix this, please see\n' +
+                  'https://github.com/PolymerElements/platinum-sw#top-level-sw-importjs');
+            }
+          }.bind(this));
     },
 
     attached: function() {
@@ -383,15 +408,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       if (this.autoRegister) {
         /**
-          * Register requires all elements in the light dom to be upgraded. This
-          * behavior was expected in Polymer 1 but no longer in Polymer 2.
-          * Elements that are imported synchronously should be upgraded after
-          * the document's readyState is interactive and a
-          * requestAnimationFrame.
-          */
+         * Register requires all elements in the light dom to be upgraded. This
+         * behavior was expected in Polymer 1 but no longer in Polymer 2.
+         * Elements that are imported synchronously should be upgraded after
+         * the document's readyState is interactive and a
+         * requestAnimationFrame.
+         */
         if (document.readyState !== 'complete' &&
             document.readyState !== 'interactive') {
-
           document.onreadystatechange = function() {
             if (document.readyState === 'interactive') {
               window.requestAnimationFrame(this.register.bind(this));

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,54 +1,57 @@
 /**
  * @license
  * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 (function(global) {
-  var VERSION = '1.0';
+var VERSION = '1.0';
 
-  function deserializeUrlParams(queryString) {
-    return new Map(queryString.split('&').map(function(keyValuePair) {
-      var splits = keyValuePair.split('=');
-      var key = decodeURIComponent(splits[0]);
-      var value = decodeURIComponent(splits[1]);
-      if (value.indexOf(',') >= 0) {
-        value = value.split(',');
-      }
-
-      return [key, value];
-    }));
-  }
-
-  global.params = deserializeUrlParams(location.search.substring(1));
-
-  if (global.params.get('version') !== VERSION) {
-    throw 'The registered script is version ' + VERSION +
-          ' and cannot be used with <platinum-sw-register> version ' + global.params.get('version');
-  }
-
-  if (global.params.has('importscript')) {
-    var scripts = global.params.get('importscript');
-    if (Array.isArray(scripts)) {
-      importScripts.apply(null, scripts);
-    } else {
-      importScripts(scripts);
+function deserializeUrlParams(queryString) {
+  return new Map(queryString.split('&').map(function(keyValuePair) {
+    var splits = keyValuePair.split('=');
+    var key = decodeURIComponent(splits[0]);
+    var value = decodeURIComponent(splits[1]);
+    if (value.indexOf(',') >= 0) {
+      value = value.split(',');
     }
-  }
 
-  if (global.params.get('skipWaiting') === 'true' && global.skipWaiting) {
-    global.addEventListener('install', function(e) {
-      e.waitUntil(global.skipWaiting());
-    });
-  }
+    return [key, value];
+  }));
+}
 
-  if (global.params.get('clientsClaim') === 'true' && global.clients && global.clients.claim) {
-    global.addEventListener('activate', function(e) {
-      e.waitUntil(global.clients.claim());
-    });
+global.params = deserializeUrlParams(location.search.substring(1));
+
+if (global.params.get('version') !== VERSION) {
+  throw 'The registered script is version ' + VERSION +
+      ' and cannot be used with <platinum-sw-register> version ' +
+      global.params.get('version');
+}
+
+if (global.params.has('importscript')) {
+  var scripts = global.params.get('importscript');
+  if (Array.isArray(scripts)) {
+    importScripts.apply(null, scripts);
+  } else {
+    importScripts(scripts);
   }
+}
+
+if (global.params.get('skipWaiting') === 'true' && global.skipWaiting) {
+  global.addEventListener('install', function(e) {
+    e.waitUntil(global.skipWaiting());
+  });
+}
+
+if (global.params.get('clientsClaim') === 'true' && global.clients &&
+    global.clients.claim) {
+  global.addEventListener('activate', function(e) {
+    e.waitUntil(global.clients.claim());
+  });
+}
 })(self);

--- a/test/controlled-promise.js
+++ b/test/controlled-promise.js
@@ -1,14 +1,15 @@
 /**
 @license
 Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
-// Provides an equivalent to navigator.serviceWorker.ready that waits for the page to be controlled,
-// as opposed to waiting for the active service worker.
+// Provides an equivalent to navigator.serviceWorker.ready that waits for the
+// page to be controlled, as opposed to waiting for the active service worker.
 // See https://github.com/slightlyoff/ServiceWorker/issues/799
 window._controlledPromise = new Promise(function(resolve) {
   // Resolve with the registration, to match the .ready promise's behavior.
@@ -21,6 +22,7 @@ window._controlledPromise = new Promise(function(resolve) {
   if (navigator.serviceWorker.controller) {
     resolveWithRegistration();
   } else {
-    navigator.serviceWorker.addEventListener('controllerchange', resolveWithRegistration);
+    navigator.serviceWorker.addEventListener(
+        'controllerchange', resolveWithRegistration);
   }
 });

--- a/test/index.html
+++ b/test/index.html
@@ -18,9 +18,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script>
       if (navigator.serviceWorker) {
         WCT.loadSuites([
-          // Keep each test suite in its own directory so that it gets a SW registered with a
-          // limited scope, just in case the browser environment is not cleared in between each
-          // test suite.
+          // Keep each test suite in its own directory so that it gets a SW registered
+          // with a limited scope, just in case the browser environment is not cleared
+          // in between each test suite.
           'platinum-sw-register/index.html?dom=shadow',
           'platinum-sw-cache/index.html?dom=shadow',
           'platinum-sw-import-script/index.html?dom=shadow',

--- a/test/platinum-sw-cache/index.html
+++ b/test/platinum-sw-cache/index.html
@@ -34,18 +34,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         suite('Precaching', function() {
           test('precache results in Cache Storage API entries', function() {
             return window._controlledPromise.then(function() {
-              return window.fetch(swc.cacheConfigFile).then(function(response) {
-                return response.json();
-              }).then(function(config) {
-                return swc.precache.concat(config.precache);
-              }).then(function(files) {
-                return Promise.all(files.map(function(file) {
-                  var url = new URL(file, window.location.href);
-                  return window.caches.match(url).then(function(cachedResponse) {
-                    assert.ok(cachedResponse, 'No match in Cache Storage API for ' + url);
+              return window.fetch(swc.cacheConfigFile)
+                  .then(function(response) {
+                    return response.json();
+                  })
+                  .then(function(config) {
+                    return swc.precache.concat(config.precache);
+                  })
+                  .then(function(files) {
+                    return Promise.all(files.map(function(file) {
+                      var url = new URL(file, window.location.href);
+                      return window.caches.match(url).then(function(cachedResponse) {
+                        assert.ok(
+                            cachedResponse,
+                            'No match in Cache Storage API for ' + url);
+                      });
+                    }));
                   });
-                }));
-              });
             });
           });
         });

--- a/test/platinum-sw-cache/sw-import.js
+++ b/test/platinum-sw-cache/sw-import.js
@@ -1,10 +1,11 @@
 /**
 @license
 Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 importScripts('../../service-worker.js');

--- a/test/platinum-sw-fetch/custom-fetch-handler.js
+++ b/test/platinum-sw-fetch/custom-fetch-handler.js
@@ -1,22 +1,17 @@
 /**
 @license
 Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 self.custom203FetchHandler = function(request) {
-  return new Response('', {
-    status: 203,
-    statusText: 'Via customFetchHandler'
-  });
+  return new Response('', {status: 203, statusText: 'Via customFetchHandler'});
 };
 
 self.custom410FetchHandler = function(request) {
-  return new Response('', {
-    status: 410,
-    statusText: 'Via customFetchHandler'
-  });
+  return new Response('', {status: 410, statusText: 'Via customFetchHandler'});
 };

--- a/test/platinum-sw-fetch/index.html
+++ b/test/platinum-sw-fetch/index.html
@@ -34,29 +34,47 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script>
       suite('Service Worker Fetch Handlers', function() {
-        test('the same-origin custom fetch handler is used when the path matches', function() {
-          return window._controlledPromise.then(function() {
-            return window.fetch('customFetch');
-          }).then(function(response) {
-            assert.equal(response.status, 203, 'Custom response status doesn\'t match');
-          });
-        });
-
-        test('the same-origin custom fetch handler isn\'t used when the path doesn\t match', function() {
-          return window._controlledPromise.then(function() {
-            return window.fetch('dummyUrlThatShould404').then(function(response) {
-              assert.equal(response.status, 404, 'Expected response status doesn\'t match');
+        test(
+            'the same-origin custom fetch handler is used when the path matches',
+            function() {
+              return window._controlledPromise
+                  .then(function() {
+                    return window.fetch('customFetch');
+                  })
+                  .then(function(response) {
+                    assert.equal(
+                        response.status,
+                        203,
+                        'Custom response status doesn\'t match');
+                  });
             });
-          });
-        });
 
-        test('the cross-origin fetch handler is used when the path and origin matches', function() {
-          return window._controlledPromise.then(function() {
-            return window.fetch('https://matching.domain/path/to/customFetch').then(function(response) {
-              assert.equal(response.status, 410, 'Custom response status doesn\'t match');
+        test(
+            'the same-origin custom fetch handler isn\'t used when the path doesn\t match',
+            function() {
+              return window._controlledPromise.then(function() {
+                return window.fetch('dummyUrlThatShould404').then(function(response) {
+                  assert.equal(
+                      response.status,
+                      404,
+                      'Expected response status doesn\'t match');
+                });
+              });
             });
-          });
-        });
+
+        test(
+            'the cross-origin fetch handler is used when the path and origin matches',
+            function() {
+              return window._controlledPromise.then(function() {
+                return window.fetch('https://matching.domain/path/to/customFetch')
+                    .then(function(response) {
+                      assert.equal(
+                          response.status,
+                          410,
+                          'Custom response status doesn\'t match');
+                    });
+              });
+            });
       });
     </script>
   </body>

--- a/test/platinum-sw-fetch/sw-import.js
+++ b/test/platinum-sw-fetch/sw-import.js
@@ -1,10 +1,11 @@
 /**
 @license
 Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 importScripts('../../service-worker.js');

--- a/test/platinum-sw-import-script/post-message-echo.js
+++ b/test/platinum-sw-import-script/post-message-echo.js
@@ -1,11 +1,12 @@
 /**
 @license
 Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 self.addEventListener('message', function(event) {
   event.ports[0].postMessage(event.data);

--- a/test/platinum-sw-import-script/sw-import.js
+++ b/test/platinum-sw-import-script/sw-import.js
@@ -1,10 +1,11 @@
 /**
 @license
 Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 importScripts('../../service-worker.js');

--- a/test/platinum-sw-register/sw-import.js
+++ b/test/platinum-sw-register/sw-import.js
@@ -1,10 +1,11 @@
 /**
 @license
 Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 importScripts('../../service-worker.js');


### PR DESCRIPTION
Runs the experimental autoformatter [webmat](https://github.com/PolymerLabs/webmat) which runs clang-format on js files and makes it so that it can run on HTML files. Please look through this PR with `?w=1` in the diff to make sure that no logic was changed.

What has changed?
You can run the formatter on the whole project by running `npm run format` and ex/include files from the formatter, and enter your custom clang-format config in a formatconfig.json see webmat readme for more!